### PR TITLE
Wait for spinner to be hidden before clicking

### DIFF
--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -65,7 +65,8 @@ class WebDriver():
         driver.get(BASE_URL)
 
         # Login to retrieve the account's trips and needed headers for later requests
-        WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.CLASS_NAME, "login-button--box"))).click()
+        WebDriverWait(driver, 30).until(EC.invisibility_of_element((By.CLASS_NAME, 'dimmer')))
+        WebDriverWait(driver, 30).until(EC.element_to_be_clickable((By.CLASS_NAME, "login-button--box"))).click()
 
         username_element = WebDriverWait(driver, 30).until(EC.presence_of_element_located((By.NAME, "userNameOrAccountNumber")))
         username_element.send_keys(account.username)


### PR DESCRIPTION
It was crashing trying to click on the login box before the spinner disappeared. This will now wait for the Spinner to be invisible and the Login button to be clickable. 

Fixes this error:
selenium.common.exceptions.ElementClickInterceptedException: Message: element click intercepted: Element <span class="login-button--box">...</span> is not clickable at point (1849, 28). Other element would receive the click: <div class="dimmer" data-qa="loading spinner">...</div>