### PR TITLE
Allow for multiple accounts/flights to be run in one instance of the script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ If there is no "Upgrading" header for that version, no post-upgrade actions need
 - A `--help` flag was added to display information on how to use the script
 - Added official Python 3.11 support
 - A [Configuration](CONFIGURATION.md) guide was written to facilitate the script's configuration
+- Allow multiple accounts/flights to be run in one instance of the script ([#33](https://github.com/jdholtz/auto-southwest-check-in/pull/33))
 
 ### Improvements
 - Optimized the script's entrypoint so the user is no longer required to install the requirements (besides Python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ If there is no "Upgrading" header for that version, no post-upgrade actions need
 ### New features
 - A `--help` flag was added to display information on how to use the script
 - Added official Python 3.11 support
+- A [Configuration](CONFIGURATION.md) guide was written to facilitate the script's configuration
 
 ### Improvements
 - Optimized the script's entrypoint so the user is no longer required to install the requirements (besides Python)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -1,0 +1,59 @@
+# Configuration
+This guide contains all the information you need to configure Auto-Southwest Check-In to your needs. A default/example configuration
+file can be found at [config.example.json](config.example.json)
+
+## Table of Contents
+- [Notifications](#notifications)
+    * [Notification URLS](#notification-urls)
+    * [Notification Level](#notification-level)
+    * [Test The Notifications](#test-the-notifications)
+- [Retrieval Interval](#retrieval-interval)
+
+## Notifications
+### Notification URLs
+Users can be notified on successful and failed check-ins. This is done through the [Apprise library][0].
+To start, first gather the service URL you want to send notifications to (information on how to create
+service URLs can be found on the [Apprise Readme][1]). Then put it in your configuration file.
+```json
+{
+  "notification_urls": "service://my_service_url"
+}
+```
+If you have more than one service you want to send notifications to, you can put them in an array:
+```json
+{
+  "notification_urls": [
+    "service://my_first_service_url",
+    "service://my_second_service_url"
+  ]
+}
+
+```
+
+### Notification Level
+You can also select the level of notifications you want to receive.
+```json
+{
+  "notification_level": 1
+}
+```
+Level 1 means you receive successful scheduling and check-in messages and all messages in later levels.\
+Level 2 means you receive only error messages (failed scheduling and check-ins).
+
+### Test The Notifications
+To test if the notification URLs work, you can run the following command
+```shell
+$ python3 southwest.py --test-notifications
+```
+
+## Retrieval Interval
+If you provide login credentials to the script, you can choose how often the script checks for new flights
+(in hours).
+```json
+{
+    "retrieval_interval": 24
+}
+```
+
+[0]: https://github.com/caronc/apprise
+[1]: https://github.com/caronc/apprise#supported-notifications

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -8,6 +8,7 @@ file can be found at [config.example.json](config.example.json)
     * [Notification Level](#notification-level)
     * [Test The Notifications](#test-the-notifications)
 - [Retrieval Interval](#retrieval-interval)
+- [Accounts](#accounts)
 
 ## Notifications
 ### Notification URLs
@@ -52,6 +53,18 @@ If you provide login credentials to the script, you can choose how often the scr
 ```json
 {
     "retrieval_interval": 24
+}
+```
+
+## Accounts
+You can add more accounts to the script, allowing you to run multiple accounts at the same time and/or not
+provide a username and password as arguments.
+```json
+{
+    "accounts": [
+        {"username": "user1", "password": "pass1"},
+        {"username": "user2", "password": "pass2"}
+    ]
 }
 ```
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -9,6 +9,7 @@ file can be found at [config.example.json](config.example.json)
     * [Test The Notifications](#test-the-notifications)
 - [Retrieval Interval](#retrieval-interval)
 - [Accounts](#accounts)
+- [Flights](#flights)
 
 ## Notifications
 ### Notification URLs
@@ -64,6 +65,18 @@ provide a username and password as arguments.
     "accounts": [
         {"username": "user1", "password": "pass1"},
         {"username": "user2", "password": "pass2"}
+    ]
+}
+```
+
+## Flights
+Similar to [Accounts](#accounts), you can also add more flights to the script, allowing you check in to multiple flights in the same instance and/or not
+provide flight information as arguments.
+```json
+{
+    "flights": [
+        {"confirmationNumber": "num1", "firstName": "John", "lastName": "Doe"},
+        {"confirmationNumber": "num2", "firstName": "Jane", "lastName": "Doe"}
     ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ information beforehand.
 - [Using The Script](#using-the-script)
     * [Running In Docker](#running-in-docker)
 - [Configuration](#configuration)
-    * [Notifications](#notifications)
-    * [Retrieval Interval](#retrieval-interval)
 
 ## Installation
 
@@ -80,60 +78,14 @@ docker run -d auto-southwest-check-in ARGS
 **Note**: The recommended restart policy for the container is `on-failed` or `no`
 
 ## Configuration
-To set up a configuration file, copy `config.example.json` to `config.json`.
+To use the default configuration file, copy `config.example.json` to `config.json`.
+
+For information on how to set up the configuration, see [Configuration.md](CONFIGURATION.md)
 
 **Note**: If you are using Docker, make sure to rebuild the container after editing the configuration
 file for your changes to be applied.
-
-### Notifications
-#### Notification URLs
-Users can be notified on successful and failed check-ins. This is done through the [Apprise library][4].
-To start, first gather the service url you want to send notifications to (information on how to create
-service urls can be found on the [Apprise Readme][5]). Then put it in your configuration file.
-```json
-{
-  "notification_urls": "service://my_service_url"
-}
-```
-If you have more than one service you want to send notifications to, you can put them in an array:
-```json
-{
-  "notification_urls": [
-    "service://my_first_service_url",
-    "service://my_second_service_url"
-  ]
-}
-
-```
-
-#### Notification Level
-You can also select the level of notifications you want to receive.
-```json
-{
-  "notification_level": 1
-}
-```
-Level 1 means you receive successful scheduling and check-in messages and all messages in later levels.\
-Level 2 means you receive only error messages (failed scheduling and check-ins).
-
-#### Test The Notifications
-To test if the notification urls work, you can run the following command
-```shell
-$ python3 southwest.py --test-notifications
-```
-
-### Retrieval Interval
-If you provide login credentials to the script, you can choose how often the script checks for new flights
-(in hours).
-```json
-{
-    "retrieval_interval": 24
-}
-```
 
 [0]: https://www.python.org/downloads/
 [1]: https://pip.pypa.io/en/stable/installation/
 [2]: https://www.google.com/chrome/
 [3]: https://www.docker.com/
-[4]: https://github.com/caronc/apprise
-[5]: https://github.com/caronc/apprise#supported-notifications

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,7 @@
 {
     "notification_urls": "",
     "notification_level": 1,
-    "retrieval_interval": 24
+    "retrieval_interval": 24,
+    "accounts": [],
+    "flights": []
 }

--- a/lib/checkin_scheduler.py
+++ b/lib/checkin_scheduler.py
@@ -28,6 +28,10 @@ class CheckInScheduler:
         self.flights = []
 
     def schedule(self, confirmation_numbers: List[str]) -> None:
+        if not self.headers:
+            # Make sure we have valid headers before scheduling
+            self.refresh_headers()
+
         prev_flight_len = len(self.flights)
 
         for confirmation_number in confirmation_numbers:

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,6 +15,7 @@ class Config:
     def __init__(self):
         # Default values are set
         self.accounts = []
+        self.flights = []
         self.notification_level = NotificationLevel.INFO
         self.notification_urls = []
         self.retrieval_interval = 24
@@ -52,6 +53,14 @@ class Config:
                 raise TypeError("'accounts' must be a list")
 
             self._parse_accounts(accounts)
+
+        if "flights" in config:
+            flights = config["flights"]
+
+            if not isinstance(flights, list):
+                raise TypeError("'flights' must be a list")
+
+            self._parse_flights(flights)
 
         if "notification_level" in config:
             self.notification_level = config["notification_level"]
@@ -100,3 +109,34 @@ class Config:
             raise TypeError("'password' must be a string")
 
         self.accounts.append([username, password])
+
+    def _parse_flights(self, flights: List[JSON]) -> None:
+        for flight in flights :
+            if not isinstance(flight, dict):
+                raise TypeError("'flights' must only contain dictionaries")
+
+            self._parse_flight(flight)
+
+    def _parse_flight(self, flight: JSON) -> None:
+        if "confirmationNumber" not in flight:
+            raise TypeError("'confirmationNumber' must be in every flight")
+
+        if "firstName" not in flight:
+            raise TypeError("'firstName' must be in every flight")
+
+        if "lastName" not in flight:
+            raise TypeError("'lastName' must be in every flight")
+
+        confirmation_number = flight["confirmationNumber"]
+        if not isinstance(confirmation_number, str):
+            raise TypeError("'confirmationNumber' must be a string")
+
+        first_name = flight["firstName"]
+        if not isinstance(first_name, str):
+            raise TypeError("'firstName' must be a string")
+
+        last_name = flight["lastName"]
+        if not isinstance(last_name, str):
+            raise TypeError("'lastName' must be a string")
+
+        self.flights.append([confirmation_number, first_name, last_name])

--- a/lib/config.py
+++ b/lib/config.py
@@ -111,7 +111,7 @@ class Config:
         self.accounts.append([username, password])
 
     def _parse_flights(self, flights: List[JSON]) -> None:
-        for flight in flights :
+        for flight in flights:
             if not isinstance(flight, dict):
                 raise TypeError("'flights' must only contain dictionaries")
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,9 +1,12 @@
 import json
 import os
 import sys
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from .general import NotificationLevel
+
+# Type alias for JSON
+JSON = Dict[str, Any]
 
 CONFIG_FILE_NAME = "config.json"
 
@@ -11,8 +14,9 @@ CONFIG_FILE_NAME = "config.json"
 class Config:
     def __init__(self):
         # Default values are set
-        self.notification_urls = []
+        self.accounts = []
         self.notification_level = NotificationLevel.INFO
+        self.notification_urls = []
         self.retrieval_interval = 24
 
         # Read the config file
@@ -26,7 +30,7 @@ class Config:
             print(err)
             sys.exit()
 
-    def _read_config(self) -> Dict[str, Any]:
+    def _read_config(self) -> JSON:
         project_dir = os.path.dirname(os.path.dirname(__file__))
         config_file = project_dir + "/" + CONFIG_FILE_NAME
 
@@ -40,18 +44,26 @@ class Config:
 
     # This method ensures the configuration values are correct and the right types.
     # Defaults are already set in the constructor to ensure a value is never null.
-    def _parse_config(self, config: Dict[str, Any]) -> None:
-        if "notification_urls" in config:
-            self.notification_urls = config["notification_urls"]
+    def _parse_config(self, config: JSON) -> None:
+        if "accounts" in config:
+            accounts = config["accounts"]
 
-            if not isinstance(self.notification_urls, (list, str)):
-                raise TypeError("'notification_urls' must be a list or string")
+            if not isinstance(accounts, list):
+                raise TypeError("'accounts' must be a list")
+
+            self._parse_accounts(accounts)
 
         if "notification_level" in config:
             self.notification_level = config["notification_level"]
 
             if not isinstance(self.notification_level, int):
                 raise TypeError("'notification_level' must be an integer")
+
+        if "notification_urls" in config:
+            self.notification_urls = config["notification_urls"]
+
+            if not isinstance(self.notification_urls, (list, str)):
+                raise TypeError("'notification_urls' must be a list or string")
 
         if "retrieval_interval" in config:
             self.retrieval_interval = config["retrieval_interval"]
@@ -64,3 +76,27 @@ class Config:
                     f"Setting 'retrieval_interval' to one as {self.retrieval_interval} hours is too low"
                 )
                 self.retrieval_interval = 1
+
+    def _parse_accounts(self, accounts: List[JSON]) -> None:
+        for account in accounts:
+            if not isinstance(account, dict):
+                raise TypeError("'accounts' must only contain dictionaries")
+
+            self._parse_account(account)
+
+    def _parse_account(self, account: JSON) -> None:
+        if "username" not in account:
+            raise TypeError("'username' must be in every account")
+
+        if "password" not in account:
+            raise TypeError("'password' must be in every account")
+
+        username = account["username"]
+        if not isinstance(username, str):
+            raise TypeError("'username' must be a string")
+
+        password = account["password"]
+        if not isinstance(password, str):
+            raise TypeError("'password' must be a string")
+
+        self.accounts.append([username, password])

--- a/lib/flight_retriever.py
+++ b/lib/flight_retriever.py
@@ -14,11 +14,11 @@ class FlightRetriever:
     provided.
     """
 
-    def __init__(self, first_name: str = None, last_name: str = None) -> None:
+    def __init__(self, config: Config, first_name: str = None, last_name: str = None) -> None:
         self.first_name = first_name
         self.last_name = last_name
 
-        self.config = Config()
+        self.config = config
         self.notification_handler = NotificationHandler(self)
         self.checkin_scheduler = CheckInScheduler(self)
 
@@ -37,10 +37,10 @@ class AccountFlightRetriever(FlightRetriever):
     are provided.
     """
 
-    def __init__(self, username: str, password: str) -> None:
+    def __init__(self, config: Config, username: str, password: str) -> None:
         self.username = username
         self.password = password
-        super().__init__()
+        super().__init__(config)
 
     def monitor_account(self) -> None:
         # Convert hours to seconds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ target-version = ['py37']
 
 [tool.coverage.run]
 branch = true
+omit = ["venv/*"]
 
 [tool.coverage.report]
 show_missing = true

--- a/tests/test_checkin_scheduler.py
+++ b/tests/test_checkin_scheduler.py
@@ -7,6 +7,7 @@ from pytest_mock import MockerFixture
 
 from lib.checkin_handler import CheckInHandler
 from lib.checkin_scheduler import CheckInScheduler
+from lib.config import Config
 from lib.flight import Flight
 from lib.flight_retriever import FlightRetriever
 from lib.general import CheckInError
@@ -17,17 +18,51 @@ from lib.webdriver import WebDriver
 # pylint: disable=protected-access
 
 
+# Don't read the config file
+@pytest.fixture(autouse=True)
+def mock_config(mocker: MockerFixture) -> None:
+    mocker.patch.object(Config, "_read_config")
+
+
 @pytest.fixture
 def test_flight(mocker: MockerFixture) -> Flight:
     mocker.patch.object(Flight, "_get_flight_time")
     return Flight({"departureAirport": {"name": None}, "arrivalAirport": {"name": None}}, "")
 
 
-def test_schedule_schedules_all_reservations(mocker: MockerFixture) -> None:
+def test_schedule_refreshes_headers_when_empty(mocker: MockerFixture) -> None:
+    mock_refresh_headers = mocker.patch.object(CheckInScheduler, "refresh_headers")
     mock_schedule_flights = mocker.patch.object(CheckInScheduler, "_schedule_flights")
     mock_new_flight_notifications = mocker.patch.object(NotificationHandler, "new_flights")
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
+    checkin_scheduler.schedule([])
+
+    mock_refresh_headers.assert_called_once()
+    mock_schedule_flights.assert_not_called()
+    mock_new_flight_notifications.assert_called_once()
+
+
+def test_schedule_does_not_refresh_headers_when_populated(mocker: MockerFixture) -> None:
+    mock_refresh_headers = mocker.patch.object(CheckInScheduler, "refresh_headers")
+    mock_schedule_flights = mocker.patch.object(CheckInScheduler, "_schedule_flights")
+    mock_new_flight_notifications = mocker.patch.object(NotificationHandler, "new_flights")
+
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
+    checkin_scheduler.headers = {"test": "headers"}
+    checkin_scheduler.schedule([])
+
+    mock_refresh_headers.assert_not_called()
+    mock_schedule_flights.assert_not_called()
+    mock_new_flight_notifications.assert_called_once()
+
+
+def test_schedule_schedules_all_reservations(mocker: MockerFixture) -> None:
+    mocker.patch.object(CheckInScheduler, "refresh_headers")
+    mock_schedule_flights = mocker.patch.object(CheckInScheduler, "_schedule_flights")
+    mock_new_flight_notifications = mocker.patch.object(NotificationHandler, "new_flights")
+
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     checkin_scheduler.schedule(["test1", "test2"])
 
     mock_schedule_flights.assert_has_calls([mock.call("test1"), mock.call("test2")])
@@ -44,7 +79,7 @@ def test_schedule_flights_schedules_all_flights_under_reservation(
     mocker.patch("lib.checkin_scheduler.Flight")
     mock_schedule_check_in = mocker.patch.object(CheckInHandler, "schedule_check_in")
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     checkin_scheduler._schedule_flights("flight1")
 
     assert len(checkin_scheduler.flights) == 2
@@ -60,7 +95,7 @@ def test_schedule_flights_does_not_schedule_already_scheduled_flights(
     mocker.patch.object(CheckInScheduler, "_flight_is_scheduled", return_value=True)
     mocker.patch("lib.checkin_scheduler.Flight")
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     checkin_scheduler._schedule_flights("flight1")
 
     assert len(checkin_scheduler.flights) == 0
@@ -71,7 +106,7 @@ def test_schedule_flights_does_not_schedule_departed_flights(mocker: MockerFixtu
     mocker.patch.object(CheckInScheduler, "_get_reservation_info", return_value=reservation_info)
     mocker.patch("lib.checkin_scheduler.Flight")
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     checkin_scheduler._schedule_flights("flight1")
 
     assert len(checkin_scheduler.flights) == 0
@@ -81,7 +116,7 @@ def test_get_reservation_info_returns_reservation_info(mocker: MockerFixture) ->
     reservation_info = {"viewReservationViewPage": {"bounds": [{"test": "reservation"}]}}
     mocker.patch("lib.checkin_scheduler.make_request", return_value=reservation_info)
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     reservation_info = checkin_scheduler._get_reservation_info("flight1")
 
     assert reservation_info == [{"test": "reservation"}]
@@ -95,7 +130,7 @@ def test_get_reservation_info_sends_error_notification_when_reservation_retrieva
         NotificationHandler, "failed_reservation_retrieval"
     )
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     reservation_info = checkin_scheduler._get_reservation_info("flight1")
 
     mock_failed_reservation_retrieval.assert_called_once()
@@ -105,7 +140,7 @@ def test_get_reservation_info_sends_error_notification_when_reservation_retrieva
 def test_flight_is_scheduled_returns_true_if_flight_is_already_scheduled(
     test_flight: Flight,
 ) -> None:
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
 
     test_flight.departure_time = datetime(1999, 12, 31)
     test_flight.departure_airport = "test_departure"
@@ -137,7 +172,7 @@ def test_flight_is_scheduled_returns_false_if_flight_is_not_scheduled(
     flight_info: Dict[str, Any],
     flight_time: datetime,
 ) -> None:
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
 
     test_flight.departure_time = datetime(1999, 12, 31)
     checkin_scheduler.flights.append(test_flight)
@@ -151,7 +186,7 @@ def test_flight_is_scheduled_returns_false_if_flight_is_not_scheduled(
 def test_set_headers_sets_new_headers(mocker: MockerFixture) -> None:
     mock_webdriver_set_headers = mocker.patch.object(WebDriver, "set_headers")
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     checkin_scheduler.refresh_headers()
     mock_webdriver_set_headers.assert_called_once()
 
@@ -169,7 +204,7 @@ def test_remove_departed_flights_removes_only_departed_flights(
     mock_datetime = mocker.patch("lib.checkin_scheduler.datetime")
     mock_datetime.utcnow.return_value = datetime(1999, 12, 31)
 
-    checkin_scheduler = CheckInScheduler(FlightRetriever())
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
     test_flight.departure_time = flight_time
     checkin_scheduler.flights.append(test_flight)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,6 +55,7 @@ def test_read_config_returns_empty_config_when_file_is_not_found(mocker: MockerF
         {"notification_level": "invalid"},
         {"retrieval_interval": "invalid"},
         {"accounts": "invalid"},
+        {"flights": "invalid"},
     ],
 )
 def test_parse_config_raises_exception_with_invalid_entries(config_content: Dict[str, Any]) -> None:
@@ -79,6 +80,7 @@ def test_parse_config_does_not_set_values_when_a_config_value_is_empty(
     mocker: MockerFixture,
 ) -> None:
     mock_parse_accounts = mocker.patch.object(config.Config, "_parse_accounts")
+    mock_parse_flights = mocker.patch.object(config.Config, "_parse_flights")
     test_config = config.Config()
     expected_config = config.Config()
 
@@ -88,6 +90,7 @@ def test_parse_config_does_not_set_values_when_a_config_value_is_empty(
     assert test_config.notification_level == expected_config.notification_level
     assert test_config.retrieval_interval == test_config.retrieval_interval
     mock_parse_accounts.assert_not_called()
+    mock_parse_flights.assert_not_called()
 
 
 def test_parse_config_sets_retrieval_interval_to_a_minimum() -> None:
@@ -97,12 +100,20 @@ def test_parse_config_sets_retrieval_interval_to_a_minimum() -> None:
     assert test_config.retrieval_interval == 1
 
 
-def test_parse_config_parses_accounts_when_available(mocker: MockerFixture) -> None:
+def test_parse_config_parses_accounts(mocker: MockerFixture) -> None:
     mock_parse_accounts = mocker.patch.object(config.Config, "_parse_accounts")
     test_config = config.Config()
     test_config._parse_config({"accounts": []})
 
     mock_parse_accounts.assert_called_once()
+
+
+def test_parse_config_parses_flights(mocker: MockerFixture) -> None:
+    mock_parse_flights = mocker.patch.object(config.Config, "_parse_flights")
+    test_config = config.Config()
+    test_config._parse_config({"flights": []})
+
+    mock_parse_flights.assert_called_once()
 
 
 @pytest.mark.parametrize("account_content", [[""], [1], [True]])
@@ -127,8 +138,8 @@ def test_parse_accounts_parses_every_account(mocker: MockerFixture) -> None:
         {},
         {"username": ""},  # No password
         {"password": ""},  # No username
-        {"username": 1, "password": "valid"},  # Invalid username type
-        {"username": "valid", "password": 1},  # Invalid password type
+        {"username": 1, "password": ""},  # Invalid username
+        {"username": "", "password": 1},  # Invalid password
     ],
 )
 def test_parse_account_raises_exception_with_invalid_entries(account_content: List[Any]) -> None:
@@ -144,3 +155,46 @@ def test_parse_account_adds_an_account() -> None:
 
     assert len(test_config.accounts) == 1
     assert test_config.accounts[0] == ["user", "pass"]
+
+
+@pytest.mark.parametrize("flight_content", [[""], [1], [True]])
+def test_parse_flights_raises_exception_with_invalid_entries(flight_content: List[Any]) -> None:
+    test_config = config.Config()
+
+    with pytest.raises(TypeError):
+        test_config._parse_flights(flight_content)
+
+
+def test_parse_flights_parses_every_flight(mocker: MockerFixture) -> None:
+    mock_parse_flight = mocker.patch.object(config.Config, "_parse_flight")
+    test_config = config.Config()
+    test_config._parse_flights([{}, {}])
+
+    assert mock_parse_flight.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "flight_content",
+    [
+        {},
+        {"firstName": "", "lastName": ""},  # No confirmation number
+        {"confirmationNumber": "", "lastName": ""},  # No first name
+        {"confirmationNumber": "", "firstName": ""},  # No first name
+        {"confirmationNumber": 1, "firstName": "", "lastName": ""},  # Invalid confirmation number
+        {"confirmationNumber": "", "firstName": 1, "lastName": ""},  # Invalid first name
+        {"confirmationNumber": "", "firstName": "", "lastName": 1},  # Invalid last name
+    ],
+)
+def test_parse_flight_raises_exception_with_invalid_entries(flight_content: List[Any]) -> None:
+    test_config = config.Config()
+
+    with pytest.raises(TypeError):
+        test_config._parse_flight(flight_content)
+
+
+def test_parse_flight_adds_a_flight() -> None:
+    test_config = config.Config()
+    test_config._parse_flight({"confirmationNumber": "num", "firstName": "John", "lastName": "Doe"})
+
+    assert len(test_config.flights) == 1
+    assert test_config.flights[0] == ["num", "John", "Doe"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytest
 from pytest_mock import MockerFixture
@@ -54,6 +54,7 @@ def test_read_config_returns_empty_config_when_file_is_not_found(mocker: MockerF
         {"notification_urls": None},
         {"notification_level": "invalid"},
         {"retrieval_interval": "invalid"},
+        {"accounts": "invalid"},
     ],
 )
 def test_parse_config_raises_exception_with_invalid_entries(config_content: Dict[str, Any]) -> None:
@@ -74,7 +75,10 @@ def test_parse_config_sets_the_correct_config_values() -> None:
     assert test_config.retrieval_interval == 20
 
 
-def test_parse_config_does_not_set_values_when_a_config_value_is_empty() -> None:
+def test_parse_config_does_not_set_values_when_a_config_value_is_empty(
+    mocker: MockerFixture,
+) -> None:
+    mock_parse_accounts = mocker.patch.object(config.Config, "_parse_accounts")
     test_config = config.Config()
     expected_config = config.Config()
 
@@ -83,6 +87,7 @@ def test_parse_config_does_not_set_values_when_a_config_value_is_empty() -> None
     assert test_config.notification_urls == expected_config.notification_urls
     assert test_config.notification_level == expected_config.notification_level
     assert test_config.retrieval_interval == test_config.retrieval_interval
+    mock_parse_accounts.assert_not_called()
 
 
 def test_parse_config_sets_retrieval_interval_to_a_minimum() -> None:
@@ -90,3 +95,52 @@ def test_parse_config_sets_retrieval_interval_to_a_minimum() -> None:
     test_config._parse_config({"retrieval_interval": -1})
 
     assert test_config.retrieval_interval == 1
+
+
+def test_parse_config_parses_accounts_when_available(mocker: MockerFixture) -> None:
+    mock_parse_accounts = mocker.patch.object(config.Config, "_parse_accounts")
+    test_config = config.Config()
+    test_config._parse_config({"accounts": []})
+
+    mock_parse_accounts.assert_called_once()
+
+
+@pytest.mark.parametrize("account_content", [[""], [1], [True]])
+def test_parse_accounts_raises_exception_with_invalid_entries(account_content: List[Any]) -> None:
+    test_config = config.Config()
+
+    with pytest.raises(TypeError):
+        test_config._parse_accounts(account_content)
+
+
+def test_parse_accounts_parses_every_account(mocker: MockerFixture) -> None:
+    mock_parse_account = mocker.patch.object(config.Config, "_parse_account")
+    test_config = config.Config()
+    test_config._parse_accounts([{}, {}])
+
+    assert mock_parse_account.call_count == 2
+
+
+@pytest.mark.parametrize(
+    "account_content",
+    [
+        {},
+        {"username": ""},  # No password
+        {"password": ""},  # No username
+        {"username": 1, "password": "valid"},  # Invalid username type
+        {"username": "valid", "password": 1},  # Invalid password type
+    ],
+)
+def test_parse_account_raises_exception_with_invalid_entries(account_content: List[Any]) -> None:
+    test_config = config.Config()
+
+    with pytest.raises(TypeError):
+        test_config._parse_account(account_content)
+
+
+def test_parse_account_adds_an_account() -> None:
+    test_config = config.Config()
+    test_config._parse_account({"username": "user", "password": "pass"})
+
+    assert len(test_config.accounts) == 1
+    assert test_config.accounts[0] == ["user", "pass"]

--- a/tests/test_flight_retriever.py
+++ b/tests/test_flight_retriever.py
@@ -2,6 +2,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from lib.checkin_scheduler import CheckInScheduler
+from lib.config import Config
 from lib.flight_retriever import AccountFlightRetriever, FlightRetriever
 from lib.webdriver import WebDriver
 
@@ -19,7 +20,7 @@ def test_flight_retriever_schedules_reservations_correctly(mocker: MockerFixture
     mock_schedule = mocker.patch.object(CheckInScheduler, "schedule")
     flights = [{"confirmationNumber": "Test1"}, {"confirmationNumber": "Test2"}]
 
-    test_retriever = FlightRetriever()
+    test_retriever = FlightRetriever(Config())
     test_retriever.schedule_reservations(flights)
 
     mock_schedule.assert_called_once_with(["Test1", "Test2"])
@@ -33,7 +34,7 @@ def test_account_FR_monitors_the_account_continuously(mocker: MockerFixture) -> 
     mock_schedule_reservations = mocker.patch.object(FlightRetriever, "schedule_reservations")
     mock_remove_departed_flights = mocker.patch.object(CheckInScheduler, "remove_departed_flights")
 
-    test_retriever = AccountFlightRetriever("", "")
+    test_retriever = AccountFlightRetriever(Config(), "", "")
 
     with pytest.raises(Exception):
         test_retriever.monitor_account()
@@ -47,7 +48,7 @@ def test_get_flights_returns_the_correct_flights(mocker: MockerFixture) -> None:
     flights = [{"flight1": "test1"}, {"flight2": "test2"}]
     mocker.patch.object(WebDriver, "get_flights", return_value=flights)
 
-    test_retriever = AccountFlightRetriever("", "")
+    test_retriever = AccountFlightRetriever(Config(), "", "")
     new_flights = test_retriever._get_flights()
 
     assert new_flights == flights

--- a/tests/test_notification_handler.py
+++ b/tests/test_notification_handler.py
@@ -2,7 +2,6 @@ import apprise
 import pytest
 from pytest_mock import MockerFixture
 
-from lib.flight_retriever import FlightRetriever
 from lib.general import NotificationLevel
 from lib.notification_handler import NotificationHandler
 
@@ -11,8 +10,9 @@ from lib.notification_handler import NotificationHandler
 
 
 @pytest.fixture
-def notification_handler() -> NotificationHandler:
-    return NotificationHandler(FlightRetriever())
+def notification_handler(mocker: MockerFixture) -> NotificationHandler:
+    mock_flight_retriever = mocker.patch("lib.flight_retriever.FlightRetriever")
+    return NotificationHandler(mock_flight_retriever)
 
 
 def test_get_account_name_returns_the_correct_name(


### PR DESCRIPTION
Fixes #26.

Multiple accounts/flights can now be specified in the configuration file. These will be monitored in the same instance of the script (in addition to the information passed in from the arguments -- although no arguments are necessary). 

Also, a Configuration Doc was added to isolate the configuration guide from the rest of the README.