### PR TITLE
Add Chrome Version Configuration Option

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -7,6 +7,7 @@ file can be found at [config.example.json](config.example.json)
     * [Notification URLS](#notification-urls)
     * [Notification Level](#notification-level)
     * [Test The Notifications](#test-the-notifications)
+- [Chrome Version](#chrome-version)
 - [Retrieval Interval](#retrieval-interval)
 - [Accounts](#accounts)
 - [Flights](#flights)
@@ -46,6 +47,15 @@ Level 2 means you receive only error messages (failed scheduling and check-ins).
 To test if the notification URLs work, you can run the following command
 ```shell
 $ python3 southwest.py --test-notifications
+```
+
+## Chrome Version
+You can specify a specific version of Google Chrome for the script to use (only the main version - e.g. 108, 109, etc.).
+This is highly recommended if you don't want to continuously keep Google Chrome on the latest version.
+```json
+{
+    "chrome_version": 110
+}
 ```
 
 ## Retrieval Interval

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ See above for the arguments that can be passed in.
 
 **Note**: The recommended restart policy for the container is `on-failed` or `no`
 
+It is advised that you [specify](CONFIGURATION.md#chrome-version) a Google Chrome version in the configuration
+file so you don't need to rebuild your Docker image often. Find the latest version that will be downloaded
+[here](https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable?id=202706&page=1).
+
 ## Configuration
 To use the default configuration file, copy `config.example.json` to `config.json`.
 

--- a/config.example.json
+++ b/config.example.json
@@ -3,5 +3,6 @@
     "notification_level": 1,
     "retrieval_interval": 24,
     "accounts": [],
-    "flights": []
+    "flights": [],
+    "chrome_version": 109
 }

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,6 +15,7 @@ class Config:
     def __init__(self):
         # Default values are set
         self.accounts = []
+        self.chrome_version = 109
         self.flights = []
         self.notification_level = NotificationLevel.INFO
         self.notification_urls = []
@@ -51,6 +52,12 @@ class Config:
                 raise TypeError("'accounts' must be a list")
 
             self._parse_accounts(accounts)
+
+        if "chrome_version" in config:
+            self.chrome_version = config["chrome_version"]
+
+            if not isinstance(self.chrome_version, int):
+                raise TypeError("'chrome_version' must be an integer")
 
         if "flights" in config:
             flights = config["flights"]

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,7 +15,7 @@ class Config:
     def __init__(self):
         # Default values are set
         self.accounts = []
-        self.chrome_version = 109
+        self.chrome_version = None
         self.flights = []
         self.notification_level = NotificationLevel.INFO
         self.notification_urls = []

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -136,14 +136,22 @@ class WebDriver:
         request_headers = driver.requests[0].headers
         self.checkin_scheduler.headers = self._get_needed_headers(request_headers)
 
-    @staticmethod
-    def _get_options() -> ChromeOptions:
+    def _get_options(self) -> ChromeOptions:
         options = ChromeOptions()
-        options.add_argument("--headless")
         options.add_argument("--disable-dev-shm-usage")  # For docker containers
 
         # Southwest detects headless browser user agents, so we have to set our own
         options.add_argument("--user-agent=" + USER_AGENT)
+
+        # This is a temporary workaround for later chrome versions. Currently, the latest
+        # version of undetected_chromedriver adds this argument correctly, but it gets
+        # detected by Southwest, so this will be here until it can bypass their bot detection.
+        chrome_version = self.checkin_scheduler.flight_retriever.config.chrome_version
+        print(chrome_version)
+        if not chrome_version or chrome_version >= 109:
+            options.add_argument("--headless=new")
+        else:
+            options.add_argument("--headless=chrome")
 
         return options
 

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -119,7 +119,12 @@ class WebDriver:
         return flights
 
     def _get_driver(self) -> Chrome:
-        driver = Chrome(options=self.options, seleniumwire_options=self.seleniumwire_options)
+        chrome_version = self.checkin_scheduler.flight_retriever.config.chrome_version
+        driver = Chrome(
+            options=self.options,
+            seleniumwire_options=self.seleniumwire_options,
+            version_main=chrome_version,
+        )
         driver.scopes = [LOGIN_URL, TRIPS_URL, RESERVATION_URL]  # Filter out unneeded URLs
         driver.get(CHECKIN_URL)
         return driver

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -147,7 +147,6 @@ class WebDriver:
         # version of undetected_chromedriver adds this argument correctly, but it gets
         # detected by Southwest, so this will be here until it can bypass their bot detection.
         chrome_version = self.checkin_scheduler.flight_retriever.config.chrome_version
-        print(chrome_version)
         if not chrome_version or chrome_version >= 109:
             options.add_argument("--headless=new")
         else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,11 +50,12 @@ def test_read_config_returns_empty_config_when_file_is_not_found(mocker: MockerF
 @pytest.mark.parametrize(
     "config_content",
     [
-        {"notification_urls": None},
-        {"notification_level": "invalid"},
-        {"retrieval_interval": "invalid"},
         {"accounts": "invalid"},
+        {"chrome_version": "invalid"},
         {"flights": "invalid"},
+        {"notification_level": "invalid"},
+        {"notification_urls": None},
+        {"retrieval_interval": "invalid"},
     ],
 )
 def test_parse_config_raises_exception_with_invalid_entries(config_content: Dict[str, Any]) -> None:
@@ -67,12 +68,18 @@ def test_parse_config_raises_exception_with_invalid_entries(config_content: Dict
 def test_parse_config_sets_the_correct_config_values() -> None:
     test_config = config.Config()
     test_config._parse_config(
-        {"notification_urls": "test_url", "notification_level": 30, "retrieval_interval": 20}
+        {
+            "chrome_version": 10,
+            "notification_level": 20,
+            "notification_urls": "test_url",
+            "retrieval_interval": 30,
+        }
     )
 
+    assert test_config.chrome_version == 10
+    assert test_config.notification_level == 20
     assert test_config.notification_urls == "test_url"
-    assert test_config.notification_level == 30
-    assert test_config.retrieval_interval == 20
+    assert test_config.retrieval_interval == 30
 
 
 def test_parse_config_does_not_set_values_when_a_config_value_is_empty(

--- a/tests/test_webdriver.py
+++ b/tests/test_webdriver.py
@@ -27,7 +27,8 @@ def test_set_headers_correctly_sets_needed_headers(mocker: MockerFixture) -> Non
     mocker.patch("lib.webdriver.WebDriverWait")
     mock_set_headers_from_request = mocker.patch.object(WebDriver, "_set_headers_from_request")
 
-    WebDriver(None).set_headers()
+    mock_checkin_scheduler = mocker.patch("lib.checkin_scheduler.CheckInScheduler")
+    WebDriver(mock_checkin_scheduler).set_headers()
     mock_set_headers_from_request.assert_called_once()
 
 
@@ -100,8 +101,9 @@ def test_get_flights_does_not_set_account_name_when_it_is_already_set(
     assert flights == "new flights"
 
 
-def test_get_driver_returns_a_webdriver_with_one_request() -> None:
-    driver = WebDriver(None)._get_driver()
+def test_get_driver_returns_a_webdriver_with_one_request(mocker: MockerFixture) -> None:
+    mock_checkin_scheduler = mocker.patch("lib.checkin_scheduler.CheckInScheduler")
+    driver = WebDriver(mock_checkin_scheduler)._get_driver()
     assert isinstance(driver, mock.Mock)
     assert driver.get.call_count == 1  # pylint: disable=no-member
 


### PR DESCRIPTION
Fixes #39 and #32.

Specifying a chrome version will allow users to not always have to use the latest version of Chrome (although not specifying it  will download the latest chromedriver version). 

A workaround was also implemented for the new headless flag in Google Chrome versions 109 and 110 (thanks to @vdude8 for finding [this](https://github.com/jdholtz/auto-southwest-check-in/issues/39#issuecomment-1427803039)). This same workaround was already implemented in newest version of `undetected_chromedriver`, but that version is currently being detected by Southwest's bot detection algorithms. I will remove this functionality once `undetected_chromedriver` is fixed. 