### PR TITLE
Add a logger

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@
 config.example.json
 Dockerfile
 LICENSE
+logs/
 pyproject.toml
 tests/
 venv

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 # Program files
 config.json
 .coverage
+logs/
 Pipfile

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ information beforehand.
 - [Using The Script](#using-the-script)
     * [Running In Docker](#running-in-docker)
 - [Configuration](#configuration)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 
 ## Installation
@@ -91,10 +92,16 @@ For information on how to set up the configuration, see [Configuration.md](CONFI
 **Note**: If you are using Docker, make sure to rebuild the container after editing the configuration
 file for your changes to be applied.
 
-## Contributing
-If you run into any issues, please file it via [GitHub Issues][5]. If you have any questions or discussion topics,
-start a [GitHub Discussion][6].
+## Troubleshooting
+To troubleshoot a problem, run the script with the `--verbose` flag. This will print all debug messages to stderr.
 
+If you run into any issues, please file it via [GitHub Issues][5]. Please attach any relevant logs (can be found in
+`logs/auto-southwest-check-in.log`) to the issue. The logs should not have any personal information but check to make
+sure before attaching it).
+
+If you have any questions or discussion topics, start a [GitHub Discussion][6].
+
+## Contributing
 Contributions are always welcome. Please read [Contributing.md](CONTRIBUTING.md) if you are considering making contributions.
 
 [0]: https://www.python.org/downloads/

--- a/lib/checkin_scheduler.py
+++ b/lib/checkin_scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List
 
@@ -12,6 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .flight_retriever import FlightRetriever
 
 VIEW_RESERVATION_URL = "mobile-air-booking/v1/mobile-air-booking/page/view-reservation/"
+logger = logging.getLogger(__name__)
 
 
 class CheckInScheduler:
@@ -30,6 +32,7 @@ class CheckInScheduler:
     def schedule(self, confirmation_numbers: List[str]) -> None:
         if not self.headers:
             # Make sure we have valid headers before scheduling
+            logger.debug("No headers set. Refreshing...")
             self.refresh_headers()
 
         prev_flight_len = len(self.flights)
@@ -40,26 +43,36 @@ class CheckInScheduler:
         self.notification_handler.new_flights(self.flights[prev_flight_len:])
 
     def refresh_headers(self) -> None:
+        logger.debug("Refreshing headers for current session")
         webdriver = WebDriver(self)
         webdriver.set_headers()
 
     def remove_departed_flights(self) -> None:
+        logger.debug(
+            "Removing departed flights. Currently have %d flights scheduled", len(self.flights)
+        )
         current_time = datetime.utcnow()
 
         for flight in self.flights[:]:
             if flight.departure_time < current_time:
                 self.flights.remove(flight)
 
+        logger.debug(
+            "Successfully removed departed flights. Now %d flights are scheduled", len(self.flights)
+        )
+
     def _schedule_flights(self, confirmation_number: str) -> None:
         reservation_info = self._get_reservation_info(confirmation_number)
+        logger.debug("%d flights found under current reservation", len(reservation_info))
 
-        # If multiple flights are under the same confirmation number, it will schedule all checkins one by one
+        # If multiple flights are under the same confirmation number, it will schedule all checkins
         for flight_info in reservation_info:
             flight = Flight(flight_info, confirmation_number)
 
             if flight_info["departureStatus"] != "DEPARTED" and not self._flight_is_scheduled(
                 flight
             ):
+                logger.debug("New flight found. Handling check-in")
                 self.flights.append(flight)
                 checkin_handler = CheckInHandler(self, flight)
                 checkin_handler.schedule_check_in()
@@ -72,11 +85,14 @@ class CheckInScheduler:
         site = VIEW_RESERVATION_URL + confirmation_number
 
         try:
+            logger.debug("Retrieving reservation info from confirmation number")
             response = make_request("GET", site, self.headers, info)
         except CheckInError as err:
+            logger.debug("Failed to retrieve reservation info. Error: %s. Exiting", err)
             self.notification_handler.failed_reservation_retrieval(err, confirmation_number)
             return []
 
+        logger.debug("Successfully retrieved reservation info")
         reservation_info = response["viewReservationViewPage"]["bounds"]
         return reservation_info
 

--- a/lib/flight_retriever.py
+++ b/lib/flight_retriever.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import time
 from datetime import datetime
@@ -8,6 +9,8 @@ from .config import Config
 from .general import LoginError
 from .notification_handler import NotificationHandler
 from .webdriver import WebDriver
+
+logger = logging.getLogger(__name__)
 
 
 class FlightRetriever:
@@ -25,6 +28,7 @@ class FlightRetriever:
         self.checkin_scheduler = CheckInScheduler(self)
 
     def schedule_reservations(self, flights: List[Dict[str, Any]]) -> None:
+        logger.debug("Scheduling reservations for %d flights", len(flights))
         confirmation_numbers = []
 
         for flight in flights:
@@ -60,15 +64,20 @@ class AccountFlightRetriever(FlightRetriever):
             # deciding how long to sleep
             time_after = datetime.utcnow()
             time_taken = (time_after - time_before).total_seconds()
-            time.sleep(retrieval_interval - time_taken)
+            sleep_time = retrieval_interval - time_taken
+            logger.debug("Sleeping for %d seconds", sleep_time)
+            time.sleep(sleep_time)
 
     def _get_flights(self) -> List[Dict[str, Any]]:
+        logger.debug("Retrieving flights for account")
         webdriver = WebDriver(self.checkin_scheduler)
 
         try:
             flights = webdriver.get_flights(self)
         except LoginError as err:
+            logger.debug("Error logging in. Error: %s. Exiting", err)
             self.notification_handler.failed_login(err)
             sys.exit()
 
+        logger.debug("Successfully retrieved %d flights", len(flights))
         return flights

--- a/lib/general.py
+++ b/lib/general.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from enum import IntEnum
 from typing import Any, Dict
@@ -5,6 +6,7 @@ from typing import Any, Dict
 import requests
 
 BASE_URL = "https://mobile.southwest.com/api/"
+logger = logging.getLogger(__name__)
 
 
 def make_request(
@@ -22,12 +24,15 @@ def make_request(
             response = requests.get(url, headers=headers, params=info)
 
         if response.status_code == 200:
+            logger.debug("Successfully made request after %d attempts", attempts)
             return response.json()
 
         attempts += 1
         time.sleep(0.5)
 
-    raise CheckInError(response.reason + " " + str(response.status_code))
+    error = response.reason + " " + str(response.status_code)
+    logger.debug("Failed to make request: %s", error)
+    raise CheckInError(error)
 
 
 # Make a custom exception when a check-in fails

--- a/lib/main.py
+++ b/lib/main.py
@@ -23,13 +23,13 @@ Log into your account:
 
 Options:
     --test-notifications Test the notification URLs configuration and exit
+    -v, --verbose        Emit debug messages to stderr
     -h, --help           Display this help and exit
-    -v, --version        Display version information and exit
+    -V, --version        Display version information and exit
 
 For more information, check out https://github.com/jdholtz/auto-southwest-check-in#readme"""
 
 LOG_FILE = "logs/auto-southwest-check-in.log"
-VERBOSITY_LEVEL = logging.INFO
 
 # Use the parent logger so the logger config is applied to every module
 # when using getLogger(__name__)
@@ -47,7 +47,7 @@ def print_usage():
 
 def check_flags(arguments: List[str]) -> None:
     """Checks for version and help flags and exits the script on success"""
-    if "--version" in arguments or "-v" in arguments:
+    if "--version" in arguments or "-V" in arguments:
         print_version()
         sys.exit()
     elif "--help" in arguments or "-h" in arguments:
@@ -55,7 +55,7 @@ def check_flags(arguments: List[str]) -> None:
         sys.exit()
 
 
-def init_logging() -> None:
+def init_logging(arguments: List[str]) -> None:
     """Sets the logger configuration for the script"""
     # Make the logging directory if it doesn't exist
     os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
@@ -75,7 +75,12 @@ def init_logging() -> None:
     file_handler.doRollover()  # Create a new log file when starting the application
 
     stream_handler = logging.StreamHandler()
-    stream_handler.setLevel(VERBOSITY_LEVEL)
+
+    if "--verbose" in arguments or "-v" in arguments:
+        stream_handler.setLevel(logging.DEBUG)
+        stream_handler.setFormatter(formatter)
+    else:
+        stream_handler.setLevel(logging.INFO)
 
     logger.addHandler(file_handler)
     logger.addHandler(stream_handler)
@@ -144,5 +149,5 @@ def set_up_check_in(arguments: List[str]):
 
 def main(arguments: List[str]) -> None:
     check_flags(arguments)
-    init_logging()
+    init_logging(arguments)
     set_up_check_in(arguments)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,7 +124,7 @@ def test_set_up_check_in_sends_test_notifications_when_flag_is_passed(
     mocker: MockerFixture,
 ) -> None:
     mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
-    main.set_up(["--test-notifications"])
+    main.set_up_check_in(["--test-notifications"])
     mock_send_notification.assert_called_once()
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import logging
 from typing import List
 from unittest import mock
 
@@ -5,10 +6,11 @@ import pytest
 from pytest_mock import MockerFixture
 
 from lib import main
-from lib.checkin_scheduler import CheckInScheduler
 from lib.config import Config
-from lib.flight_retriever import AccountFlightRetriever, FlightRetriever
 from lib.notification_handler import NotificationHandler
+
+# Don't write logs to a file during testing
+main.LOG_FILE = "/dev/null"
 
 
 # We don't actually want the config to read the file for these tests
@@ -63,6 +65,19 @@ def test_check_flags_does_not_exit_when_flags_are_not_matched(
     mock_exit.assert_not_called()
 
 
+def test_init_logging_initializes_the_logger_correctly(mocker: MockerFixture) -> None:
+    mock_makedirs = mocker.patch("os.makedirs")
+
+    # Don't actually rollover during testing
+    mocker.patch.object(logging.handlers.RotatingFileHandler, "doRollover")
+
+    main.init_logging()
+    logger = logging.getLogger("lib")
+
+    mock_makedirs.assert_called_once()
+    assert len(logger.handlers) == 2
+
+
 def test_set_up_accounts_starts_all_accounts_in_proceses(mocker: MockerFixture) -> None:
     config = Config()
     config.accounts = [["user1", "pass1"], ["user2", "pass2"]]
@@ -89,7 +104,9 @@ def test_set_up_flights_starts_all_flights_in_proceses(mocker: MockerFixture) ->
     assert mock_process.return_value.start.call_count == len(config.flights)
 
 
-def test_set_up_sends_test_notifications_when_flag_is_passed(mocker: MockerFixture) -> None:
+def test_set_up_check_in_sends_test_notifications_when_flag_is_passed(
+    mocker: MockerFixture,
+) -> None:
     mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
     main.set_up(["--test-notifications"])
     mock_send_notification.assert_called_once()
@@ -103,37 +120,39 @@ def test_set_up_sends_test_notifications_when_flag_is_passed(mocker: MockerFixtu
         (["test", "John", "Doe"], 0, 1),
     ],
 )
-def test_set_up_sets_up_account_and_flight_with_arguments(
+def test_set_up_check_in_sets_up_account_and_flight_with_arguments(
     mocker: MockerFixture, arguments: List[str], accounts_len: int, flights_len: int
 ) -> None:
     mock_set_up_accounts = mocker.patch("lib.main.set_up_accounts")
     mock_set_up_flights = mocker.patch("lib.main.set_up_flights")
 
-    main.set_up(arguments)
+    main.set_up_check_in(arguments)
 
     assert len(mock_set_up_accounts.call_args[0][0].accounts) == accounts_len
     assert len(mock_set_up_flights.call_args[0][0].flights) == flights_len
 
 
-def test_set_up_sends_error_message_when_arguments_are_invalid(
-    capsys: pytest.CaptureFixture[str],
+def test_set_up_check_in_sends_error_message_when_arguments_are_invalid(
+    caplog: pytest.CaptureFixture[str],
 ) -> None:
     arguments = ["1", "2", "3", "4"]
 
     with pytest.raises(SystemExit):
-        main.set_up(arguments)
+        main.set_up_check_in(arguments)
+    output = caplog.record_tuples[1]
 
-    output = capsys.readouterr().out
+    assert output[1] == logging.ERROR
+    assert "Invalid arguments" in output[2]
+    assert "--help" in output[2]
 
-    assert "Invalid arguments" in output
-    assert "--help" in output
 
-
-def test_main_sets_up_script(mocker: MockerFixture) -> None:
+def test_main_sets_up_the_script(mocker: MockerFixture) -> None:
     mock_check_flags = mocker.patch("lib.main.check_flags")
-    mock_set_up = mocker.patch("lib.main.set_up")
+    mock_init_logging = mocker.patch("lib.main.init_logging")
+    mock_set_up_check_in = mocker.patch("lib.main.set_up_check_in")
     arguments = ["test", "arguments"]
 
     main.main(arguments)
     mock_check_flags.assert_called_once_with(arguments)
-    mock_set_up.assert_called_once_with(arguments)
+    mock_init_logging.assert_called_once()
+    mock_set_up_check_in.assert_called_once_with(arguments)


### PR DESCRIPTION
Add a logger to the script. This will help both developers and users debug problems better. Log messages should not contain any sensitive information (name, account, etc.), so users should be able to attach the file to a GitHub issue (they should still check beforehand to make sure).

By default, all log messages are written to a file in the `logs` directory. A new log file is created whenever the script starts up or it gets too big (Four backup logs are kept). Debug messages can also be printed to the console by using the `--verbose` flag.