### PR TITLE
Fix OverflowError occuring when sleep length is too large

### DIFF
--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -56,13 +56,26 @@ class CheckInHandler:
         # Only try to refresh the headers if the checkin is more than ten minutes away
         if sleep_time > 0:
             logger.debug("Sleeping until ten minutes before check-in...")
-            time.sleep(sleep_time)
+            self.safe_sleep(sleep_time)
             self.checkin_scheduler.refresh_headers()
 
         current_time = datetime.utcnow()
         sleep_time = (checkin_time - current_time).total_seconds()
         logger.debug("Sleeping until check-in: %d seconds...", sleep_time)
         time.sleep(sleep_time)
+
+    @staticmethod
+    def safe_sleep(total_sleep_time: int) -> None:
+        """
+        If the total sleep time is too long, an overflow error could be reached.
+        Therefore, the script will continuously sleep in two week periods to avoid
+        this issue
+        """
+        two_weeks = 60 * 60 * 24 * 14
+        while total_sleep_time > 0:
+            sleep_time = min(total_sleep_time, two_weeks)
+            time.sleep(sleep_time)
+            total_sleep_time -= sleep_time
 
     def _check_in(self) -> None:
         """

--- a/tests/test_checkin_handler.py
+++ b/tests/test_checkin_handler.py
@@ -82,6 +82,18 @@ def test_wait_for_check_in_refreshes_headers_ten_minutes_before_check_in(
     mock_refresh_headers.assert_called_once()
 
 
+@pytest.mark.parametrize(["weeks", "expected_sleep_calls"], [(0, 0), (1, 1), (3, 2)])
+def test_safe_sleep_sleeps_in_intervals(
+    mocker: MockerFixture, weeks: int, expected_sleep_calls: int
+) -> None:
+    mock_sleep = mocker.patch("time.sleep")
+
+    total_sleep_time = weeks * 7 * 24 * 60 * 60
+    CheckInHandler.safe_sleep(total_sleep_time)
+
+    assert mock_sleep.call_count == expected_sleep_calls
+
+
 def test_check_in_sends_error_notification_when_check_in_fails(
     mocker: MockerFixture, checkin_handler: CheckInHandler
 ) -> None:


### PR DESCRIPTION
Fixes #44.

If a flight is too far out in the future, `time.sleep` could throw an OverflowError (Windows has a ~2 month limit). This PR fixes that issue by sleeping in two week intervals until the time of the check-in, ensuring an OverflowError will never occur.