### PR TITLE
Filter out non-flight type reservations

### DIFF
--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -130,7 +130,7 @@ class WebDriver:
 
         driver.quit()
 
-        return flights
+        return [flight for flight in flights if flight["tripType"] == "FLIGHT"]
 
     def _get_driver(self) -> Chrome:
         logger.debug("Starting webdriver for current session")

--- a/tests/test_webdriver.py
+++ b/tests/test_webdriver.py
@@ -82,7 +82,7 @@ def test_get_flights_sets_account_name_when_it_is_not_set(
 
     mock_set_headers_from_request.assert_called_once_with(mock_driver)
     mock_set_account_name.assert_called_once_with(mock_flight_retriever, {"name": "John Doe"})
-    assert flights == [{'tripType': 'FLIGHT'}]
+    assert flights == [{"tripType": "FLIGHT"}]
 
 
 @pytest.mark.usefixtures("mock_get_options")
@@ -117,15 +117,17 @@ def test_get_flights_only_returns_flight_trip_type(
 ) -> None:
     mocker.patch("lib.webdriver.WebDriverWait")
     mocker.patch.object(WebDriver, "_get_driver", return_value=mock_driver)
-    mock_set_headers_from_request = mocker.patch.object(WebDriver, "_set_headers_from_request")
-    mock_set_account_name = mocker.patch.object(WebDriver, "_set_account_name")
+    mocker.patch.object(WebDriver, "_set_headers_from_request")
 
     request_one = Request(method="GET", url="", headers={})
     request_one.response = Response(status_code=200, reason="", headers={})
 
     request_two = Request(method="GET", url="", headers={})
     request_two.response = Response(status_code=200, reason="", headers={})
-    request_two.response.body = '{"upcomingTripsPage": [{"tripType": "FLIGHT"}, {"tripType": "FLIGHT"}, {"tripType": "CAR"}]}'
+    request_two.response.body = (
+        '{"upcomingTripsPage": [{"tripType": "FLIGHT"}, '
+        '{"tripType": "FLIGHT"}, {"tripType": "CAR"}]}'
+    )
 
     mock_driver.requests = [request_one, request_two]
 


### PR DESCRIPTION
Thanks for the great tool! 

I noticed recently I started seeing an error like this:
```Failed to retrieve reservation for {redacted} with confirmation number XXX06390US0. Reason: Bad Request 400.```

Since the confirmation number was clearly not formatted in the typical manner (six characters long), I figured there must be another type of confirmation number that this tool was not taking into account. Sure enough, when looking at the API response it was getting back a reservation that looked something like this:

```{
            "dates": { "first": "2023-02-24", "second": "2023-02-26" },
            "destinationDescription": "Payless, Mid-size - JFK",
            "confirmationNumber": "XXX06390US0",
            "tripType": "CAR",
            ...
}```

This PR fixes the issue for me. I've been running this code for a week or two and I've not encountered any more errors, and check-ins have continued to succeed.