### PR TITLE
Add Docker Image to Public Repository

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,6 @@ Dockerfile
 LICENSE
 logs/
 pyproject.toml
+setup.cfg
 tests/
 venv

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,45 @@
+name: Build and Publish Docker Images
+
+on:
+  release:
+    types: [published]
+
+  push:
+    branches:
+      - develop
+
+jobs:
+  run-tests:
+    uses: ./.github/workflows/tests.yml
+  build-and-push-images:
+    runs-on: ubuntu-latest
+    # Do not build and push the images if all of the tests don't pass
+    needs: run-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      # A new tagged release is published, which builds :tag and :latest
+      - name: Build and push :tag
+        if: github.event_name == 'release'
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/auto-southwest-check-in:${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/auto-southwest-check-in:latest
+
+      # Develop branch push, which builds :develop
+      - name: Build and push :develop
+        if: ${{ github.ref }} == "refs/heads/develop"
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/auto-southwest-check-in:develop

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,14 +7,25 @@ on:
   push:
     branches:
       - develop
+    # Only build the image when a file in the image is updated
+    # These paths are files in the git repository from
+    # .dockerignore (except the Docker files)
+    paths-ignore:
+      - ".editorconfig"
+      - ".github"
+      - "!.github/workflows/docker.yml" # Still run on changes to this file
+      - ".gitignore"
+      - ".pre-commit-config.yaml"
+      - "**.md"
+      - "config.example.json"
+      - "LICENSE"
+      - "pyproject.toml"
+      - "setup.cfg"
+      - "tests"
 
 jobs:
-  run-tests:
-    uses: ./.github/workflows/tests.yml
   build-and-push-images:
     runs-on: ubuntu-latest
-    # Do not build and push the images if all of the tests don't pass
-    needs: run-tests
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -61,6 +61,8 @@ Type: Integer
 
 You can specify a specific version of Google Chrome for the script to use (only the main version - e.g. 108, 109, etc.).
 This is highly recommended if you don't want to continuously keep Google Chrome on the latest version.
+
+**Note**: This should not be used in a Docker container because the Google Chrome version is retrieved automatically.
 ```json
 {
     "chrome_version": 110

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENTRYPOINT ["python3", "southwest.py"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ can be found [here][4]. To pull the latest image, run:
 ```shell
 docker pull jdholtz/auto-southwest-check-in
 ```
-To download a specific version, append `:vX.X.X` to the end of the image name. You can also append the
+To download a specific version, append `:vX.X` to the end of the image name. You can also append the
 `:develop` tag instead to use the latest development version.
 
 To run the image, you can use a command such as:

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ by adding the `--volume /path/to/config.json:/app/config.json` flag before the i
 
 **Note**: The recommended restart policy for the container is `on-failed` or `no`
 
+Additional usage for the Docker container can be found in the [public repository][4].
+
 ## Configuration
 To use the default configuration file, copy `config.example.json` to `config.json`.
 

--- a/README.md
+++ b/README.md
@@ -65,24 +65,22 @@ If you want the latest features of the script, you can use the `develop` branch 
 can be viewed in the Changelog). However, keep in mind that changes to this branch do not ensure reliability.
 
 ### Running In Docker
-
-The application can also be run in a container using [Docker][3]. To build the image, run the following command:
+The application can also be run in a container using [Docker][3]. The Docker repository for this project
+can be found [here][4]. To pull the latest image, run:
 ```shell
-$ docker build -f Dockerfile . -t auto-southwest-check-in
+$ docker pull jdholtz/auto-southwest-check-in
 ```
-**Note**: Re-run the build command whenever you update the script.
+To download a specific version, append `:vX.X.X` to the end of the image name. Additionally, you can append the
+`:develop` tag to use the latest development version.
 
 To run the image, you can use a command such as:
 ```shell
-docker run -d auto-southwest-check-in ARGS
+docker run -d jdholtz/auto-southwest-check-in ARGS
 ```
-See above for the arguments that can be passed in.
+See above for the arguments that can be passed in. You can optionally attach a configuration file to the container
+by adding the `--volume /path/to/config.json:/app/config.json` flag before the image name.
 
 **Note**: The recommended restart policy for the container is `on-failed` or `no`
-
-It is advised that you [specify](CONFIGURATION.md#chrome-version) a Google Chrome version in the configuration
-file so you don't need to rebuild your Docker image often. Find the latest version that will be downloaded
-[here][4].
 
 ## Configuration
 To use the default configuration file, copy `config.example.json` to `config.json`.
@@ -108,6 +106,6 @@ Contributions are always welcome. Please read [Contributing.md](CONTRIBUTING.md)
 [1]: https://pip.pypa.io/en/stable/installation/
 [2]: https://www.google.com/chrome/
 [3]: https://www.docker.com/
-[4]: https://www.ubuntuupdates.org/package/google_chrome/stable/main/base/google-chrome-stable?id=202706&page=1
+[4]: https://hub.docker.com/repository/docker/jdholtz/auto-southwest-check-in
 [5]: https://github.com/jdholtz/auto-southwest-check-in/issues/new/choose
 [6]: https://github.com/jdholtz/auto-southwest-check-in/discussions/new/choose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Auto-Southwest Check-In
-Running this script will automatically check you into your flight 24 hours before your flight.
+Running this script will automatically check you into your flight 24 hours beforehand.
 
 This script can also log in to your Southwest account and automatically schedule check-ins as
 flights are scheduled.
@@ -11,8 +11,8 @@ information beforehand.
 - [Installation](#installation)
     * [Prerequisites](#prerequisites)
     * [Upgrading](#upgrading)
-- [Using The Script](#using-the-script)
-    * [Running In Docker](#running-in-docker)
+- [Using the Script](#using-the-script)
+    * [Running in Docker](#running-in-docker)
 - [Configuration](#configuration)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
@@ -26,13 +26,15 @@ information beforehand.
 
 First, download the script onto your computer
 ```shell
-$ git clone https://github.com/jdholtz/auto-southwest-check-in.git
-$ cd auto-southwest-check-in
+git clone https://github.com/jdholtz/auto-southwest-check-in.git
+cd auto-southwest-check-in
 ```
 Then, install the needed packages for the script
 ```shell
-$ pip install -r requirements.txt
+pip install -r requirements.txt
 ```
+
+See [Running in Docker](#running-in-docker) for information on how to install and run the script in Docker.
 
 ### Upgrading
 When updating the script, it is important to follow the [Changelog](CHANGELOG.md) for any actions
@@ -40,22 +42,27 @@ that need to be performed.
 
 To get the script's current version, run the following command:
 ```shell
-$ python3 southwest.py --version
+python3 southwest.py --version
 ```
 
 To update the script, simply run:
 ```shell
-$ git pull
+git pull
 ```
 
-## Using The Script
+## Using the Script
 To schedule a check-in, run the following command:
 ```shell
-$ python3 southwest.py CONFIRMATION_NUMBER FIRST_NAME LAST_NAME
+python3 southwest.py CONFIRMATION_NUMBER FIRST_NAME LAST_NAME
 ```
 Alternatively, you can log in to your account, which will automatically check you in to all of your flights
 ```shell
-$ python3 southwest.py USERNAME PASSWORD
+python3 southwest.py USERNAME PASSWORD
+```
+
+For the full usage of the script, run:
+```shell
+python southwest.py --help
 ```
 
 **Note**: The script will check the entire party in under the same reservation, so there is no need
@@ -64,14 +71,14 @@ to create more than one instance of the script per reservation.
 If you want the latest features of the script, you can use the `develop` branch (documented changes
 can be viewed in the Changelog). However, keep in mind that changes to this branch do not ensure reliability.
 
-### Running In Docker
+### Running in Docker
 The application can also be run in a container using [Docker][3]. The Docker repository for this project
 can be found [here][4]. To pull the latest image, run:
 ```shell
-$ docker pull jdholtz/auto-southwest-check-in
+docker pull jdholtz/auto-southwest-check-in
 ```
-To download a specific version, append `:vX.X.X` to the end of the image name. Additionally, you can append the
-`:develop` tag to use the latest development version.
+To download a specific version, append `:vX.X.X` to the end of the image name. You can also append the
+`:develop` tag instead to use the latest development version.
 
 To run the image, you can use a command such as:
 ```shell
@@ -82,7 +89,7 @@ by adding the `--volume /path/to/config.json:/app/config.json` flag before the i
 
 **Note**: The recommended restart policy for the container is `on-failed` or `no`
 
-Additional usage for the Docker container can be found in the [public repository][4].
+Additional information on the Docker container can be found in the [public repository][4].
 
 ## Configuration
 To use the default configuration file, copy `config.example.json` to `config.json`.
@@ -95,9 +102,9 @@ file for your changes to be applied.
 ## Troubleshooting
 To troubleshoot a problem, run the script with the `--verbose` flag. This will print all debug messages to stderr.
 
-If you run into any issues, please file it via [GitHub Issues][5]. Please attach any relevant logs (can be found in
+If you run into any issues, please file it via [GitHub Issues][5]. Please attach any relevant logs (found in
 `logs/auto-southwest-check-in.log`) to the issue. The logs should not have any personal information but check to make
-sure before attaching it).
+sure before attaching it.
 
 If you have any questions or discussion topics, start a [GitHub Discussion][6].
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# The Chrome version is set as an environment variable so it can be automatically
+# read inside the script. This makes it so users don't have to provide the 'chrome_version'
+# option in the config.json
+_CHROME_VERSION=$(google-chrome-stable --version | awk -F '[ .]' '{print $3}') python3 southwest.py "$@"

--- a/lib/config.py
+++ b/lib/config.py
@@ -17,11 +17,17 @@ class Config:
     def __init__(self):
         # Default values are set
         self.accounts = []
-        self.chrome_version = None
         self.flights = []
         self.notification_level = NotificationLevel.INFO
         self.notification_urls = []
         self.retrieval_interval = 24
+
+        # _CHROME_VERSION will be set in the Docker container
+        self.chrome_version = os.getenv("_CHROME_VERSION")
+        if isinstance(self.chrome_version, str):
+            # Environment variables are strings but chrome_version needs
+            # to be an integer
+            self.chrome_version = int(self.chrome_version)
 
         # Set the configuration values if provided
         try:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,13 @@ def mock_open(mocker: MockerFixture) -> None:
     mocker.patch("json.load")
 
 
+def test_config_sets_chrome_version_from_the_environment_variable(mocker: MockerFixture) -> None:
+    mocker.patch("os.getenv", return_value="10")
+
+    test_config = config.Config()
+    assert test_config.chrome_version == 10
+
+
 def test_config_exits_on_error_in_config_file(mocker: MockerFixture) -> None:
     mocker.patch.object(config.Config, "_parse_config", side_effect=TypeError())
 


### PR DESCRIPTION
Fixes #49.

This commit adds a workflow to automatically build the Docker image whenever a release is published (with tags `:latest` and `:vX.X.X`). Additionally, a Docker image is published every push in the develop branch with the `:develop` tag.

Additionally, update the documentation to point users to download from the public repository instead of building it themselves.

The one problem with the Docker image being downloaded instead of built is that the user doesn't know which version Google Chrome is. To handle this, a `docker-entrypoint.sh` script was added to automatically retrieve the currently downloaded version of Chrome and set an environment variable for the script to read.