### PR TITLE
Add ARM support for Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,6 +45,7 @@ jobs:
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/auto-southwest-check-in:${{ github.event.release.tag_name }}
             ${{ secrets.DOCKER_HUB_USERNAME }}/auto-southwest-check-in:latest
+          platforms: linux/amd64,linux/arm64
 
       # Develop branch push, which builds :develop
       - name: Build and push :develop
@@ -54,3 +55,4 @@ jobs:
           push: true
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/auto-southwest-check-in:develop
+          platforms: linux/amd64,linux/arm64

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,10 +60,8 @@ $ python3 southwest.py --test-notifications
 Default: The latest stable version \
 Type: Integer
 
-You can specify a specific version of Google Chrome for the script to use (only the main version - e.g. 108, 109, etc.).
-This is highly recommended if you don't want to continuously keep Google Chrome on the latest version.
-
-**Note**: This should not be used in a Docker container because the Google Chrome version is retrieved automatically.
+You can specify a specific version of your Chromium browser for the script to use (only the main version - e.g. 108, 109, etc.).
+This is highly recommended if you don't want to continuously keep your Chromium browser on the latest version.
 ```json
 {
     "chrome_version": 110

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -8,6 +8,7 @@ file can be found at [config.example.json](config.example.json)
     * [Notification Level](#notification-level)
     * [Test The Notifications](#test-the-notifications)
 - [Chrome Version](#chrome-version)
+- [Chromedriver Path](#chromedriver-path)
 - [Retrieval Interval](#retrieval-interval)
 - [Accounts](#accounts)
 - [Flights](#flights)
@@ -66,6 +67,19 @@ This is highly recommended if you don't want to continuously keep Google Chrome 
 ```json
 {
     "chrome_version": 110
+}
+```
+
+## Chromedriver Path
+Default: The path of the Chromedriver executable downloaded by undetected_chromedriver \
+Type: String
+
+You can specify a custom path of the Chromedriver executable for the script to use.
+
+**Note**: This should not be used in a Docker container because the Chromedriver path is set automatically.
+```json
+{
+    "chromedriver_path": "/usr/bin/chromedriver"
 }
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,16 @@
-FROM ubuntu:22.10
+FROM python:3.10-alpine
 
 WORKDIR /app
 
-# Needed for python to show logs in all processes
-ENV PYTHONUNBUFFERED 1
+# Used in the script to point to the correct Chromedriver executable
+ENV _CHROMEDRIVER_PATH="/usr/bin/chromedriver"
 
-RUN apt-get update && apt-get install -y python3 python3-pip wget
-
-# Download google-chrome
-RUN wget https://dl-ssl.google.com/linux/linux_signing_key.pub -O /tmp/google.pub && \
-    gpg --no-default-keyring --keyring /etc/apt/keyrings/google-chrome.gpg --import /tmp/google.pub && \
-    echo 'deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome.gpg] http://dl.google.com/linux/chrome/deb/ stable main' | \
-    tee /etc/apt/sources.list.d/google-chrome.list
-
-RUN apt-get update && apt-get -y install google-chrome-stable
+# gcc, libffi-dev, and musl-dev are dependencies needed for building Python wheels
+RUN apk add --update --no-cache chromium chromium-chromedriver gcc libffi-dev musl-dev
 
 COPY requirements.txt requirements.txt
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-ENTRYPOINT ["./docker-entrypoint.sh"]
+ENTRYPOINT ["python3", "-u", "southwest.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.11-alpine
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ information beforehand.
 ### Prerequisites
 - [Python 3.7+][0]
 - [Pip][1]
-- [Google Chrome (Version 101+)][2]
+- [Any Chromium-based browser][2]
 
 First, download the script onto your computer
 ```shell
@@ -113,7 +113,7 @@ Contributions are always welcome. Please read [Contributing.md](CONTRIBUTING.md)
 
 [0]: https://www.python.org/downloads/
 [1]: https://pip.pypa.io/en/stable/installation/
-[2]: https://www.google.com/chrome/
+[2]: https://en.wikipedia.org/wiki/Chromium_(web_browser)#Active
 [3]: https://www.docker.com/
 [4]: https://hub.docker.com/repository/docker/jdholtz/auto-southwest-check-in
 [5]: https://github.com/jdholtz/auto-southwest-check-in/issues/new/choose

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# The Chrome version is set as an environment variable so it can be automatically
-# read inside the script. This makes it so users don't have to provide the 'chrome_version'
-# option in the config.json
-_CHROME_VERSION=$(google-chrome-stable --version | awk -F '[ .]' '{print $3}') python3 southwest.py "$@"

--- a/lib/config.py
+++ b/lib/config.py
@@ -17,17 +17,14 @@ class Config:
     def __init__(self):
         # Default values are set
         self.accounts = []
+        self.chrome_version = None
         self.flights = []
         self.notification_level = NotificationLevel.INFO
         self.notification_urls = []
         self.retrieval_interval = 24
 
-        # _CHROME_VERSION will be set in the Docker container
-        self.chrome_version = os.getenv("_CHROME_VERSION")
-        if isinstance(self.chrome_version, str):
-            # Environment variables are strings but chrome_version needs
-            # to be an integer
-            self.chrome_version = int(self.chrome_version)
+        # _CHROMEDRIVER_PATH is set in the Docker container
+        self.chromedriver_path = os.getenv("_CHROMEDRIVER_PATH", None)
 
         # Set the configuration values if provided
         try:
@@ -69,6 +66,13 @@ class Config:
 
             if not isinstance(self.chrome_version, int):
                 raise TypeError("'chrome_version' must be an integer")
+
+        if "chromedriver_path" in config:
+            self.chromedriver_path = config["chromedriver_path"]
+            logger.debug("Setting custom Chromedriver path")
+
+            if not isinstance(self.chromedriver_path, str):
+                raise TypeError("'chromedriver_path' must be a string")
 
         if "flights" in config:
             flights = config["flights"]

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -135,8 +135,10 @@ class WebDriver:
 
     def _get_driver(self) -> Chrome:
         logger.debug("Starting webdriver for current session")
+        chromedriver_path = self.checkin_scheduler.flight_retriever.config.chromedriver_path
         chrome_version = self.checkin_scheduler.flight_retriever.config.chrome_version
         driver = Chrome(
+            driver_executable_path=chromedriver_path,
             options=self.options,
             seleniumwire_options=self.seleniumwire_options,
             version_main=chrome_version,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,11 +18,11 @@ def mock_open(mocker: MockerFixture) -> None:
     mocker.patch("json.load")
 
 
-def test_config_sets_chrome_version_from_the_environment_variable(mocker: MockerFixture) -> None:
-    mocker.patch("os.getenv", return_value="10")
+def test_config_sets_chromedriver_path_from_environment_variable(mocker: MockerFixture) -> None:
+    mocker.patch("os.getenv", return_value="/test/path")
 
     test_config = config.Config()
-    assert test_config.chrome_version == 10
+    assert test_config.chromedriver_path == "/test/path"
 
 
 def test_config_exits_on_error_in_config_file(mocker: MockerFixture) -> None:
@@ -59,6 +59,7 @@ def test_read_config_returns_empty_config_when_file_is_not_found(mocker: MockerF
     [
         {"accounts": "invalid"},
         {"chrome_version": "invalid"},
+        {"chromedriver_path": None},
         {"flights": "invalid"},
         {"notification_level": "invalid"},
         {"notification_urls": None},
@@ -77,6 +78,7 @@ def test_parse_config_sets_the_correct_config_values() -> None:
     test_config._parse_config(
         {
             "chrome_version": 10,
+            "chromedriver_path": "/test/path",
             "notification_level": 20,
             "notification_urls": "test_url",
             "retrieval_interval": 30,
@@ -84,6 +86,7 @@ def test_parse_config_sets_the_correct_config_values() -> None:
     )
 
     assert test_config.chrome_version == 10
+    assert test_config.chromedriver_path == "/test/path"
     assert test_config.notification_level == 20
     assert test_config.notification_urls == "test_url"
     assert test_config.retrieval_interval == 30


### PR DESCRIPTION
Fixes #27.

Many improvements were made to the Docker image:
- Chromium is now used, enabling the image to be built and ran on ARM architecture
- Alpine Linux is now used, reducing image size by 40%

Disadvantages:
- Since Alpine Linux is used, a few Python packages have to be built from source. This makes the build time much longer (about 5 minutes longer on my machine)

Other Important Changes
- The script now officially supports any Chromium-based browser (it only unofficially did before)
- Users can specify the path to a custom Chromedriver executable in the `config.json` if they choose to. This can also be used in place of `chrome_version` to stop undetected_chromedriver from trying to download the latest Chromedriver