### PR TITLE
Added fare type to fare_checker

### DIFF
--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -92,6 +92,10 @@ class FareChecker:
         # Next, get the search information needed to change the flight
         logger.debug("Retrieving search information for the current flight")
         info = response["viewReservationViewPage"]["_links"]["change"]
+        
+        # Fix for Southwest API adding an extra slash in changeFlightPage's href.
+        if "/v1/" in info["href"]:
+            info["href"] = info["href"][1:]
         site = BOOKING_URL + info["href"]
         response = make_request("GET", site, self.headers, info["query"], max_attempts=7)
 

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -34,6 +34,7 @@ class FareChecker:
         # The sign key will not exist if the price amount is 0
         sign = flight_price.get("sign", "")
         price_info = f"{sign}{flight_price['amount']} {flight_price['currencyCode']}"
+        
         logger.debug("Flight price change found for %s", price_info)
 
         if sign == "-":
@@ -69,10 +70,10 @@ class FareChecker:
         # we need to know what page to get based on what flight we requested (in case two flights
         # (round-trip flights) are on the same reservation)
         bound_page = "outboundPage" if query["outbound"]["isChangeBound"] else "inboundPage"
-        if bound_page == "outboundPage":
-            fare_type = fare_type_bounds[0]["fareProductDetails"]["fareProductId"]
-        else:
-            fare_type = fare_type_bounds[1]["fareProductDetails"]["fareProductId"]
+        
+        bound = 0 if bound_page == "outboundPage" else 1
+        
+        fare_type = fare_type_bounds[bound]["fareProductDetails"]["fareProductId"]
 
         logger.debug("Retrieving matching flights")
         response = make_request("POST", site, self.headers, query, max_attempts=7)

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -47,13 +47,7 @@ class FareChecker:
         # Get the fares from the same flight
         for new_flight in flights:
             if new_flight["departureTime"] == flight.local_departure_time:
-                flight_fares = new_flight["fares"]
-                break
-
-        # Ensure we are comparing equivalent fare types
-        for fare in flight_fares:
-            if fare["_meta"]["fareProductId"] == fare_type:
-                return fare["priceDifference"]
+                return self._get_matching_fare(new_flight["fares"], fare_type)
 
     def _get_matching_flights(self, flight: Flight) -> Union[List[JSON], str]:
         """
@@ -127,3 +121,11 @@ class FareChecker:
         # is round-trip. Otherwise, just generate a query including 'outbound'
         bounds = ["outbound", "inbound"]
         return dict(zip(bounds, search_terms))
+
+    @staticmethod
+    def _get_matching_fare(fares: JSON, fare_type: str) -> JSON:
+        for fare in fares:
+            if fare["_meta"]["fareProductId"] == fare_type:
+                return fare["priceDifference"]
+
+        raise KeyError(f"No fare type found matching {fare_type}")

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -70,13 +70,9 @@ class FareChecker:
         # (round-trip flights) are on the same reservation)
         bound_page = "outboundPage" if query["outbound"]["isChangeBound"] else "inboundPage"
         if bound_page == "outboundPage":
-            fare_type = fare_type_bounds[0]["fareProductDetails"][
-            "fareProductId"
-        ]
+            fare_type = fare_type_bounds[0]["fareProductDetails"]["fareProductId"]
         else:
-            fare_type = fare_type_bounds[1]["fareProductDetails"][
-            "fareProductId"
-        ]
+            fare_type = fare_type_bounds[1]["fareProductDetails"]["fareProductId"]
 
         logger.debug("Retrieving matching flights")
         response = make_request("POST", site, self.headers, query, max_attempts=7)

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -34,7 +34,6 @@ class FareChecker:
         # The sign key will not exist if the price amount is 0
         sign = flight_price.get("sign", "")
         price_info = f"{sign}{flight_price['amount']} {flight_price['currencyCode']}"
-
         logger.debug("Flight price change found for %s", price_info)
 
         if sign == "-":

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -34,7 +34,7 @@ class FareChecker:
         # The sign key will not exist if the price amount is 0
         sign = flight_price.get("sign", "")
         price_info = f"{sign}{flight_price['amount']} {flight_price['currencyCode']}"
-        
+
         logger.debug("Flight price change found for %s", price_info)
 
         if sign == "-":
@@ -70,9 +70,9 @@ class FareChecker:
         # we need to know what page to get based on what flight we requested (in case two flights
         # (round-trip flights) are on the same reservation)
         bound_page = "outboundPage" if query["outbound"]["isChangeBound"] else "inboundPage"
-        
+
         bound = 0 if bound_page == "outboundPage" else 1
-        
+
         fare_type = fare_type_bounds[bound]["fareProductDetails"]["fareProductId"]
 
         logger.debug("Retrieving matching flights")

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -89,10 +89,6 @@ class FareChecker:
         # Next, get the search information needed to change the flight
         logger.debug("Retrieving search information for the current flight")
         info = response["viewReservationViewPage"]["_links"]["change"]
-        
-        # Fix for Southwest API adding an extra slash in changeFlightPage's href.
-        if "/v1/" in info["href"]:
-            info["href"] = info["href"][1:]
         site = BOOKING_URL + info["href"]
         response = make_request("GET", site, self.headers, info["query"], max_attempts=7)
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -12,6 +12,9 @@ logger = logging.getLogger(__name__)
 def make_request(
     method: str, site: str, headers: Dict[str, Any], info: Dict[str, str], max_attempts=20
 ) -> Dict[str, Any]:
+    # Ensure the URL is not malformed
+    site = site.replace("//", "/").lstrip("/")
+
     url = BASE_URL + site
 
     # In the case that your server and the Southwest server aren't in sync,

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -11,8 +11,8 @@ from selenium.webdriver.support.ui import WebDriverWait
 from seleniumwire.request import Response
 from seleniumwire.undetected_chromedriver import Chrome, ChromeOptions
 
+from .general import LoginError
 from .log import get_logger
-from .utils import LoginError
 
 if TYPE_CHECKING:  # pragma: no cover
     from .checkin_scheduler import CheckInScheduler
@@ -26,9 +26,6 @@ RESERVATION_URL = BASE_URL + "/api/mobile-air-operations/v1/mobile-air-operation
 
 # Southwest's code when logging in with the incorrect information
 INVALID_CREDENTIALS_CODE = 400518024
-
-# Southwest's code when logging too many requests
-TOO_MANY_REQUESTS_CODE = 429999999
 
 logger = get_logger(__name__)
 
@@ -109,13 +106,7 @@ class WebDriver:
         password_element.send_keys(flight_retriever.password)
         password_element.submit()
 
-        while not driver.requests:
-            time.sleep(0.5)
-
-        while driver.requests[0].response is None:
-            time.sleep(0.5)
-
-        response = driver.requests[0].response
+        response = self._wait_for_response(driver)
         if response.status_code != 200:
             driver.quit()
             error = self._handle_login_error(response)
@@ -137,6 +128,9 @@ class WebDriver:
         # This page is also loaded when we log in, so we might as well grab it instead of
         # requesting again later
 
+        while len(driver.requests) < 2 or not driver.requests[1].response:
+            time.sleep(0.5)
+
         flights = json.loads(driver.requests[1].response.body)["upcomingTripsPage"]
 
         driver.quit()
@@ -153,8 +147,12 @@ class WebDriver:
             seleniumwire_options=self.seleniumwire_options,
             version_main=chrome_version,
         )
+
+        # Delete any requests that could have been made while the driver was being initialized
         del driver.requests
-        driver.scopes = [LOGIN_URL, TRIPS_URL, RESERVATION_URL]  # Filter out unneeded URLs
+
+        # Filter out unneeded URLs
+        driver.scopes = [LOGIN_URL, TRIPS_URL, RESERVATION_URL]
 
         logger.debug("Loading Southwest Check-In page")
         driver.get(CHECKIN_URL)
@@ -162,21 +160,15 @@ class WebDriver:
 
     def _set_headers_from_request(self, driver: Chrome) -> None:
         # Retrieving the headers could fail if the form isn't given enough time to submit
-        WebDriverWait(driver, 60).until(
-            EC.element_to_be_clickable(
-                (
-                    By.CSS_SELECTOR,
-                    """#appContents > div.check-in >
-                                    div > div.reservation-retrieval-form > div >
-                                    form > fieldset > div > div.segment > button""",
-                )
-            )
-        )
-
-        time.sleep(1)
         logger.debug("Setting valid headers from previous request")
         request_headers = driver.requests[0].headers
         self.checkin_scheduler.headers = self._get_needed_headers(request_headers)
+
+    def _wait_for_response(self, driver: Chrome) -> Response:
+        while not driver.requests or not driver.requests[0].response:
+            time.sleep(0.5)
+
+        return driver.requests[0].response
 
     def _get_options(self) -> ChromeOptions:
         options = ChromeOptions()
@@ -199,9 +191,6 @@ class WebDriver:
         if body.get("code") == INVALID_CREDENTIALS_CODE:
             logger.debug("Invalid credentials provided when attempting to log in")
             reason = "Invalid credentials"
-        elif body.get("code") == TOO_MANY_REQUESTS_CODE:
-            logger.debug("Too many requests have been made to the Southwest API.")
-            reason = "Too many requests"
         else:
             logger.debug("Logging in failed for an unknown reason")
             reason = "Unknown"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,12 @@
 import pytest
-import requests_mock
 from pytest_mock import MockerFixture
+from requests_mock.mocker import Mocker as RequestMocker
 
 from lib import utils
 
 
 def test_make_request_raises_exception_on_failure(
-    requests_mock: requests_mock.mocker.Mocker, mocker: MockerFixture
+    requests_mock: RequestMocker, mocker: MockerFixture
 ) -> None:
     mock_sleep = mocker.patch("time.sleep")
     requests_mock.post(utils.BASE_URL + "test", status_code=400, reason="error")
@@ -17,7 +17,7 @@ def test_make_request_raises_exception_on_failure(
     assert mock_sleep.call_count == 5
 
 
-def test_make_request_correctly_posts_data(requests_mock: requests_mock.mocker.Mocker) -> None:
+def test_make_request_correctly_posts_data(requests_mock: RequestMocker) -> None:
     mock_post = requests_mock.post(
         utils.BASE_URL + "test", status_code=200, text='{"success": "post"}'
     )
@@ -33,7 +33,7 @@ def test_make_request_correctly_posts_data(requests_mock: requests_mock.mocker.M
     assert last_request.json() == {"test": "json"}
 
 
-def test_make_request_correctly_gets_data(requests_mock: requests_mock.mocker.Mocker) -> None:
+def test_make_request_correctly_gets_data(requests_mock: RequestMocker) -> None:
     mock_post = requests_mock.get(
         utils.BASE_URL + "test", status_code=200, text='{"success": "get"}'
     )
@@ -46,3 +46,11 @@ def test_make_request_correctly_gets_data(requests_mock: requests_mock.mocker.Mo
     assert last_request.method == "GET"
     assert last_request.url == utils.BASE_URL + "test?test=params"
     assert last_request.headers["header"] == "test"
+
+
+def test_make_request_handles_malformed_URLs(requests_mock: RequestMocker) -> None:
+    mock_post = requests_mock.get(utils.BASE_URL + "test/test2", status_code=200, text="{}")
+    utils.make_request("GET", "/test//test2", {}, {})
+
+    last_request = mock_post.last_request
+    assert last_request.url == utils.BASE_URL + "test/test2"


### PR DESCRIPTION
This is my first time contributing to a public repo so hopefully I am doing this correctly. I ran precommit and made the changes that were suggested. However, the only thing I couldn't do was the pytesting. This broke the tests for webdriver and fare_checker and I don't know how to fix them as I've never done python tests before.

I made changes to `webdriver.py` and `fare_checker.py`

`webdriver.py` :
- Added the 429 error code from the Southwest API and logged it.
- Changed the logic to wait for a request to populate and then wait for a response to that request. We only attempt to grab headers if the request was successful rather than trying to grab headers and then check if the login was valid.
- Changed to an implicit WebDriverWait before grabbing headers rather than a hard coded 10 second wait.

`fare_checker.py`:
- Added a method to grab the fare_type of the current flight (called _get_fare_type)
- Changed the _get_flight_price method to accept the fare_type as an argument, and grabbed the proper fare_price for the correct fare_type before returning the price difference.

With these changes in place, I have been able to successfully monitor fare prices for my WGA+ flights and I was properly notified of a lower fare.