### PR TITLE
Handle flight changes and cancellations

### DIFF
--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -28,6 +28,7 @@ class CheckInHandler:
     def __init__(self, checkin_scheduler: CheckInScheduler, flight: Flight) -> None:
         self.checkin_scheduler = checkin_scheduler
         self.flight = flight
+        self.process = Process(target=self._set_check_in)
 
         self.notification_handler = self.checkin_scheduler.notification_handler
         self.first_name = self.checkin_scheduler.flight_retriever.first_name
@@ -35,8 +36,11 @@ class CheckInHandler:
 
     def schedule_check_in(self) -> None:
         logger.debug("Scheduling check-in for current flight")
-        process = Process(target=self._set_check_in)
-        process.start()
+        self.process.start()
+
+    def stop_check_in(self) -> None:
+        logger.debug("Stopping check-in for current flight")
+        self.process.terminate()
 
     def _set_check_in(self) -> None:
         # Starts to check in five seconds early in case the Southwest server is ahead of your server

--- a/lib/flight.py
+++ b/lib/flight.py
@@ -27,6 +27,15 @@ class Flight:
         self.local_departure_time = flight_info["departureTime"]
         self.local_arrival_time = flight_info["arrivalTime"]
 
+    def __eq__(self, other: Flight) -> bool:
+        # Define how two flights are equal to each other
+        return (
+            isinstance(other, Flight)
+            and self.departure_airport == other.departure_airport
+            and self.destination_airport == other.destination_airport
+            and self.departure_time == other.departure_time
+        )
+
     def _get_flight_time(self, flight: Dict[str, Any]) -> datetime:
         flight_date = f"{flight['departureDate']} {flight['departureTime']}"
         departure_airport_code = flight["departureAirport"]["code"]

--- a/tests/test_checkin_handler.py
+++ b/tests/test_checkin_handler.py
@@ -14,8 +14,8 @@ from lib.utils import RequestError
 @pytest.fixture
 def checkin_handler(mocker: MockerFixture) -> CheckInHandler:
     test_flight = mocker.patch("lib.checkin_handler.Flight")
-    test_flight.departure_time = datetime(1999, 12, 31, 18, 29)
 
+    mocker.patch("lib.checkin_handler.Process")
     mock_checkin_scheduler = mocker.patch("lib.checkin_scheduler.CheckInScheduler")
     return CheckInHandler(mock_checkin_scheduler, test_flight)
 
@@ -23,13 +23,23 @@ def checkin_handler(mocker: MockerFixture) -> CheckInHandler:
 def test_schedule_check_in_starts_a_process(
     mocker: MockerFixture, checkin_handler: CheckInHandler
 ) -> None:
-    mock_process = mocker.patch("lib.checkin_handler.Process")
+    mock_process = checkin_handler.process
     mock_process.start = mock.Mock()
 
     checkin_handler.schedule_check_in()
 
-    mock_process.assert_called_once_with(target=checkin_handler._set_check_in)
-    mock_process.return_value.start.assert_called_once()
+    mock_process.start.assert_called_once()
+
+
+def test_stop_check_in_stops_a_process(
+    mocker: MockerFixture, checkin_handler: CheckInHandler
+) -> None:
+    mock_process = checkin_handler.process
+    mock_process.terminate = mock.Mock()
+
+    checkin_handler.stop_check_in()
+
+    mock_process.terminate.assert_called_once()
 
 
 def test_set_check_in_correctly_sets_up_check_in_process(

--- a/tests/test_checkin_scheduler.py
+++ b/tests/test_checkin_scheduler.py
@@ -1,5 +1,4 @@
-from datetime import datetime
-from typing import Any, Dict
+from typing import List
 from unittest import mock
 
 import pytest
@@ -25,7 +24,7 @@ def mock_config(mocker: MockerFixture) -> None:
 
 
 @pytest.fixture
-def test_flight(mocker: MockerFixture) -> Flight:
+def test_flights(mocker: MockerFixture) -> List[Flight]:
     mocker.patch.object(Flight, "_get_flight_time")
     flight_info = {
         "departureAirport": {"name": None},
@@ -33,46 +32,26 @@ def test_flight(mocker: MockerFixture) -> Flight:
         "departureTime": None,
         "arrivalTime": None,
     }
-    return Flight(flight_info, "")
+    return [Flight(flight_info, ""), Flight(flight_info, "")]
 
 
-def test_schedule_refreshes_headers_when_empty(mocker: MockerFixture) -> None:
-    mock_refresh_headers = mocker.patch.object(CheckInScheduler, "refresh_headers")
+def test_process_reservations_handles_all_reservations(mocker: MockerFixture) -> None:
+    mock_get_flights = mocker.patch.object(
+        CheckInScheduler, "_get_flights", return_value=["flight"]
+    )
+    mock_get_new_flights = mocker.patch.object(
+        CheckInScheduler, "_get_new_flights", return_value=["flight"]
+    )
     mock_schedule_flights = mocker.patch.object(CheckInScheduler, "_schedule_flights")
-    mock_new_flight_notifications = mocker.patch.object(NotificationHandler, "new_flights")
+    mock_remove_old_flights = mocker.patch.object(CheckInScheduler, "_remove_old_flights")
 
     checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
-    checkin_scheduler.schedule([])
+    checkin_scheduler.process_reservations(["test1", "test2"])
 
-    mock_refresh_headers.assert_called_once()
-    mock_schedule_flights.assert_not_called()
-    mock_new_flight_notifications.assert_called_once()
-
-
-def test_schedule_does_not_refresh_headers_when_populated(mocker: MockerFixture) -> None:
-    mock_refresh_headers = mocker.patch.object(CheckInScheduler, "refresh_headers")
-    mock_schedule_flights = mocker.patch.object(CheckInScheduler, "_schedule_flights")
-    mock_new_flight_notifications = mocker.patch.object(NotificationHandler, "new_flights")
-
-    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
-    checkin_scheduler.headers = {"test": "headers"}
-    checkin_scheduler.schedule([])
-
-    mock_refresh_headers.assert_not_called()
-    mock_schedule_flights.assert_not_called()
-    mock_new_flight_notifications.assert_called_once()
-
-
-def test_schedule_schedules_all_reservations(mocker: MockerFixture) -> None:
-    mocker.patch.object(CheckInScheduler, "refresh_headers")
-    mock_schedule_flights = mocker.patch.object(CheckInScheduler, "_schedule_flights")
-    mock_new_flight_notifications = mocker.patch.object(NotificationHandler, "new_flights")
-
-    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
-    checkin_scheduler.schedule(["test1", "test2"])
-
-    mock_schedule_flights.assert_has_calls([mock.call("test1"), mock.call("test2")])
-    mock_new_flight_notifications.assert_called_once()
+    mock_get_flights.assert_has_calls([mock.call("test1"), mock.call("test2")])
+    mock_get_new_flights.assert_called_once_with(["flight", "flight"])
+    mock_schedule_flights.assert_called_once_with(["flight"])
+    mock_remove_old_flights.assert_called_once_with(["flight", "flight"])
 
 
 def test_refresh_headers_sets_new_headers(mocker: MockerFixture) -> None:
@@ -83,69 +62,27 @@ def test_refresh_headers_sets_new_headers(mocker: MockerFixture) -> None:
     mock_webdriver_set_headers.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    ["flight_time", "expected_len"],
-    [
-        (datetime(2000, 1, 1), 1),
-        (datetime(1999, 12, 30), 0),
-    ],
-)
-def test_remove_departed_flights_removes_only_departed_flights(
-    mocker: MockerFixture, test_flight: Flight, flight_time: datetime, expected_len: int
-) -> None:
-    mock_datetime = mocker.patch("lib.checkin_scheduler.datetime")
-    mock_datetime.utcnow.return_value = datetime(1999, 12, 31)
-
-    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
-    test_flight.departure_time = flight_time
-    checkin_scheduler.flights.append(test_flight)
-
-    checkin_scheduler.remove_departed_flights()
-
-    assert len(checkin_scheduler.flights) == expected_len
-
-
-def test_schedule_flights_schedules_all_flights_under_reservation(
+def test_get_flights_retrieves_all_flights_under_reservation(
     mocker: MockerFixture,
 ) -> None:
     reservation_info = [{"departureStatus": "WAITING"}, {"departureStatus": "WAITING"}]
     mocker.patch.object(CheckInScheduler, "_get_reservation_info", return_value=reservation_info)
 
-    mocker.patch.object(CheckInScheduler, "_flight_is_scheduled", return_value=False)
     mocker.patch("lib.checkin_scheduler.Flight")
-    mock_schedule_check_in = mocker.patch.object(CheckInHandler, "schedule_check_in")
-
     checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
-    checkin_scheduler._schedule_flights("flight1")
+    flights = checkin_scheduler._get_flights("flight1")
 
-    assert len(checkin_scheduler.flights) == 2
-    assert mock_schedule_check_in.call_count == 2
-
-
-def test_schedule_flights_does_not_schedule_already_scheduled_flights(
-    mocker: MockerFixture,
-) -> None:
-    reservation_info = [{"departureStatus": "WAITING"}]
-    mocker.patch.object(CheckInScheduler, "_get_reservation_info", return_value=reservation_info)
-
-    mocker.patch.object(CheckInScheduler, "_flight_is_scheduled", return_value=True)
-    mocker.patch("lib.checkin_scheduler.Flight")
-
-    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
-    checkin_scheduler._schedule_flights("flight1")
-
-    assert len(checkin_scheduler.flights) == 0
+    assert len(flights) == 2
 
 
-def test_schedule_flights_does_not_schedule_departed_flights(mocker: MockerFixture) -> None:
+def test_get_flights_does_not_retrieve_departed_flights(mocker: MockerFixture) -> None:
     reservation_info = [{"departureStatus": "DEPARTED"}]
     mocker.patch.object(CheckInScheduler, "_get_reservation_info", return_value=reservation_info)
-    mocker.patch("lib.checkin_scheduler.Flight")
 
     checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
-    checkin_scheduler._schedule_flights("flight1")
+    flights = checkin_scheduler._get_flights("flight1")
 
-    assert len(checkin_scheduler.flights) == 0
+    assert len(flights) == 0
 
 
 def test_get_reservation_info_returns_reservation_info(mocker: MockerFixture) -> None:
@@ -173,62 +110,51 @@ def test_get_reservation_info_sends_error_notification_when_reservation_retrieva
     assert reservation_info == []
 
 
-def test_flight_is_scheduled_returns_true_if_flight_is_already_scheduled(
-    test_flight: Flight,
+def test_get_new_flights_gets_flights_not_already_scheduled(
+    mocker: MockerFixture, test_flights: List[Flight]
 ) -> None:
+    flight1 = test_flights[0]
+    flight2 = test_flights[1]
+    # Change the airport so it is seen as a new flight
+    flight2.departure_airport = "LAX"
+
     checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
+    checkin_scheduler.flights = [flight1]
 
-    test_flight.departure_time = datetime(1999, 12, 31)
-    test_flight.departure_airport = "test_departure"
-    test_flight.destination_airport = "test_destination"
-    checkin_scheduler.flights.append(test_flight)
+    new_flights = checkin_scheduler._get_new_flights([flight1, flight2])
 
-    assert checkin_scheduler._flight_is_scheduled(test_flight) is True
+    assert new_flights == [flight2]
 
 
-@pytest.mark.parametrize(
-    ["flight_info", "flight_time"],
-    [
-        (
-            {
-                "departureAirport": {"name": None},
-                "arrivalAirport": {"name": None},
-                "departureTime": None,
-                "arrivalTime": None,
-            },
-            datetime(1999, 12, 30),
-        ),
-        (
-            {
-                "departureAirport": {"name": "test"},
-                "arrivalAirport": {"name": None},
-                "departureTime": None,
-                "arrivalTime": None,
-            },
-            datetime(1999, 12, 31),
-        ),
-        (
-            {
-                "departureAirport": {"name": None},
-                "arrivalAirport": {"name": "test"},
-                "departureTime": None,
-                "arrivalTime": None,
-            },
-            datetime(1999, 12, 31),
-        ),
-    ],
-)
-def test_flight_is_scheduled_returns_false_if_flight_is_not_scheduled(
-    test_flight: Flight,
-    flight_info: Dict[str, Any],
-    flight_time: datetime,
+def test_schedule_flights_schedules_all_flights(
+    mocker: MockerFixture, test_flights: List[Flight]
 ) -> None:
+    mock_schedule_check_in = mocker.patch.object(CheckInHandler, "schedule_check_in")
+    mock_new_flights_notification = mocker.patch.object(NotificationHandler, "new_flights")
+
     checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
+    checkin_scheduler._schedule_flights(test_flights)
 
-    test_flight.departure_time = datetime(1999, 12, 31)
-    checkin_scheduler.flights.append(test_flight)
+    assert len(checkin_scheduler.flights) == 2
+    assert len(checkin_scheduler.checkin_handlers) == 2
+    assert mock_schedule_check_in.call_count == 2
+    mock_new_flights_notification.assert_called_once_with(test_flights)
 
-    new_flight = Flight(flight_info, "")
-    new_flight.departure_time = flight_time
 
-    assert checkin_scheduler._flight_is_scheduled(new_flight) is False
+def test_remove_old_flights_removes_flights_not_currently_scheduled(
+    mocker: MockerFixture, test_flights: List[Flight]
+) -> None:
+    test_flights[0].departure_airport = "LAX"
+    mock_stop_check_in = mocker.patch.object(CheckInHandler, "stop_check_in")
+    checkin_scheduler = CheckInScheduler(FlightRetriever(Config()))
+    checkin_scheduler.flights = test_flights
+    checkin_scheduler.checkin_handlers = [
+        CheckInHandler(checkin_scheduler, test_flights[0]),
+        CheckInHandler(checkin_scheduler, test_flights[1]),
+    ]
+
+    checkin_scheduler._remove_old_flights([test_flights[1]])
+
+    assert len(checkin_scheduler.flights) == 1
+    assert len(checkin_scheduler.checkin_handlers) == 1
+    mock_stop_check_in.assert_called_once()

--- a/tests/test_flight.py
+++ b/tests/test_flight.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict
 from unittest import mock
 
 import pytest
@@ -22,8 +23,54 @@ def test_flight() -> Flight:
     }
 
     # Needs to be mocked so it isn't run only when Flight is instantiated
-    with mock.patch.object(Flight, "_get_flight_time"):
+    with mock.patch.object(Flight, "_get_flight_time", return_value=None):
         return Flight(flight_info, "test_num")
+
+
+def test_flights_with_the_same_attributes_are_equal(mocker: MockerFixture) -> None:
+    mocker.patch.object(Flight, "_get_flight_time")
+    flight_info = {
+        "departureAirport": {"name": None},
+        "arrivalAirport": {"name": None},
+        "departureTime": None,
+        "arrivalTime": None,
+    }
+    flight1 = Flight(flight_info, "")
+    flight2 = Flight(flight_info, "")
+
+    assert flight1 == flight2
+
+
+@pytest.mark.parametrize(
+    "flight_info",
+    [
+        {
+            "departureAirport": {"name": "test"},
+            "arrivalAirport": {"name": None},
+            "departureTime": None,
+            "arrivalTime": None,
+        },
+        {
+            "departureAirport": {"name": None},
+            "arrivalAirport": {"name": "test"},
+            "departureTime": None,
+            "arrivalTime": None,
+        },
+        {
+            "departureAirport": {"name": None},
+            "arrivalAirport": {"name": None},
+            "departureTime": "12:08",
+            "arrivalTime": None,
+        },
+    ],
+)
+def test_flights_with_different_attributes_are_not_equal(
+    mocker: MockerFixture, test_flight: Flight, flight_info: Dict[str, Any]
+) -> None:
+    mocker.patch.object(Flight, "_get_flight_time", return_value=flight_info["departureTime"])
+    new_flight = Flight(flight_info, "")
+
+    assert test_flight != new_flight
 
 
 def test_get_flight_time_returns_the_correct_time(


### PR DESCRIPTION
Fixes #101. Old flights will always now be removed before their fares are checked. The IndexError should not occur because Southwest should always return the flights we want.
    
Flights are retrieved every interval. Whenever new flights are found, they are scheduled for check-ins (same behavior as before). Whenever flights already scheduled for check-in are not found in these flights retrieved during the interval, their check-ins are stopped and they are removed from the flight list (they were either changed or cancelled).
