### PR TITLE
Fix process handling on Windows and Mac

### DIFF
--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -54,7 +54,12 @@ class CheckInHandler:
 
         # Wait so zombie (defunct) processes are not created
         logger.debug(f"Waiting for process with PID {self.pid} to be terminated")
-        os.waitpid(self.pid, 0)
+        try:
+            os.waitpid(self.pid, 0)
+        except ChildProcessError:
+            # Processes are cleaned up without needing waitpid on Windows
+            pass
+
         logger.debug(f"Process with PID {self.pid} successfully terminated")
 
     def _set_check_in(self) -> None:

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -241,5 +241,11 @@ class WebDriver:
 
     def _quit_browser(self, driver: Chrome) -> None:
         driver.quit()
-        os.waitpid(driver.browser_pid, 0)
-        os.waitpid(driver.service.process.pid, 0)
+
+        try:
+            # Wait so zombie (defunct) processes are not created
+            os.waitpid(driver.browser_pid, 0)
+            os.waitpid(driver.service.process.pid, 0)
+        except ChildProcessError:
+            # Processes are cleaned up without needing waitpid on Windows
+            pass

--- a/tests/test_checkin_handler.py
+++ b/tests/test_checkin_handler.py
@@ -44,6 +44,18 @@ def test_stop_check_in_stops_a_process_by_killing_its_pid(
     mock_os_waitpid.assert_called_once_with(checkin_handler.pid, 0)
 
 
+def test_stop_check_in_handles_child_process_error(
+    mocker: MockerFixture, checkin_handler: CheckInHandler
+) -> None:
+    mock_os_kill = mocker.patch("os.kill")
+    mock_os_waitpid = mocker.patch("os.waitpid", side_effect=ChildProcessError)
+
+    checkin_handler.stop_check_in()
+
+    mock_os_kill.assert_called_once_with(checkin_handler.pid, signal.SIGTERM)
+    mock_os_waitpid.assert_called_once_with(checkin_handler.pid, 0)
+
+
 def test_set_check_in_correctly_sets_up_check_in_process(
     mocker: MockerFixture, checkin_handler: CheckInHandler
 ) -> None:

--- a/tests/test_webdriver.py
+++ b/tests/test_webdriver.py
@@ -336,3 +336,16 @@ def test_quit_browser_quits_driver_successfully(
     ]
     mock_driver.quit.assert_called_once()
     mock_os_waitpid.assert_has_calls(expected_calls)
+
+
+def test_quit_browser_handles_child_process_error(
+    mocker: MockerFixture, mock_driver: mock.Mock
+) -> None:
+    mock_checkin_scheduler = mocker.patch("lib.checkin_scheduler.CheckInScheduler")
+    mock_os_waitpid = mocker.patch("os.waitpid", side_effect=ChildProcessError)
+
+    webdriver = WebDriver(mock_checkin_scheduler)
+    webdriver._quit_browser(mock_driver)
+
+    mock_driver.quit.assert_called_once()
+    mock_os_waitpid.assert_called_once_with(mock_driver.browser_pid, 0)


### PR DESCRIPTION
Fixes #118 and #119. 

When multiprocessing uses the 'spawn' start method, the Process object cannot be an instance variable as it can't be pickled. This PR changes the previous implementation to only keep track of the Process ID. Then, the `os` module is used to kill the process when we need to.

Additionally, `os.waitpid()` is used (isn't needed in Windows) to ensure killed processes don't turn into zombie/defunct processes. Now, no zombie processes are left from this script.