### PR TITLE
Add account and reservation-specific configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ If there is no "Upgrading" header for that version, no post-upgrade actions need
 
 ### Upcoming
 
+### New Features
+- Account and reservation-specific configurations are now supported. See
+[Accounts and Reservations](CONFIGURATION.md#accounts-and-reservations) for more
+information
+([#124](https://github.com/jdholtz/auto-southwest-check-in/pull/124))
+
 ### Bug Fixes
 - Fix incorrect price parsing when fares are not available for a flight
 ([#122](https://github.com/jdholtz/auto-southwest-check-in/issues/122))
+
+### Upgrading
+- The 'flights' key in the configuration file was renamed to 'reservations'. See the
+[reservation configuration](CONFIGURATION.md#reservations) for more information.
 
 
 ## 4.3 (2023-07-13)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -2,6 +2,9 @@
 This guide contains all the information you need to configure Auto-Southwest Check-In to your needs. A default/example configuration
 file can be found at [config.example.json](config.example.json)
 
+Auto-Southwest Check-In supports both global configuration and account/reservation-specific configuration. See
+[Accounts and Reservations](#accounts-and-reservations) for more information.
+
 ## Table of Contents
 - [Fare Check](#fare-check)
 - [Notifications](#notifications)
@@ -11,8 +14,9 @@ file can be found at [config.example.json](config.example.json)
 - [Chrome Version](#chrome-version)
 - [Chromedriver Path](#chromedriver-path)
 - [Retrieval Interval](#retrieval-interval)
-- [Accounts](#accounts)
-- [Reservations](#reservations)
+- [Accounts and Reservations](#accounts-and-reservations)
+    * [Accounts](#accounts)
+    * [Reservations](#reservations)
 
 ## Fare Check
 Default: false \
@@ -109,7 +113,12 @@ disable account/fare monitoring, set this option to `0` (The account/fares will 
 }
 ```
 
-## Accounts
+## Accounts and Reservations
+You can also add more [accounts](#accounts) and [reservations](#reservations) to the script through the configuration file.
+Additionally, you can optionally specify [configuration options](#account-and-reservation-specific-configuration) for each
+account and reservation.
+
+### Accounts
 Default: [] \
 Type: List
 
@@ -124,11 +133,11 @@ provide a username and password as arguments.
 }
 ```
 
-## Reservations
+### Reservations
 Default: [] \
 Type: List
 
-Similar to [Accounts](#accounts), you can also add more reservations to the script, allowing you check in to multiple reservations in the same instance
+You can also add more reservations to the script, allowing you check in to multiple reservations in the same instance
 and/or not provide reservation information as arguments.
 ```json
 {
@@ -138,6 +147,54 @@ and/or not provide reservation information as arguments.
     ]
 }
 ```
+
+
+### Account and Reservation-specific configuration
+Setting specific configuration values for an account or reservation allows you to fully customize how you want them to be
+monitored by the script. Here is a list of configuration values that can be applied to an individual account or reservation:
+- [Fare Check](#fare-check)
+- [Notification URLS](#notification-urls)
+- [Notification Level](#notification-level)
+- [Retrieval Interval](#retrieval-interval)
+
+Not all options have to be specified for each account or reservation. If an option is not specified, the top-level value is used
+(or the default value if no top-level value is specified either). Any accounts or reservations specified through the command line
+will use all of the top-level values.
+
+An important note about notification URLs: An account or reservation with specific notification URLs will send notifications to those
+URLs as well as URLs specified globally.
+
+#### Examples
+Here are a few examples of how the configuration options can be specified:
+
+In this example, `user1`'s account will not check for lower flight fares. However, `user2`'s account will as the top-level value for
+`check_fares` is `true`.
+```json
+{
+    "check_fares": true,
+    "accounts": [
+        {"username": "user1", "password": "pass1", "check_fares": false},
+        {"username": "user2", "password": "pass2"}
+    ]
+}
+```
+
+In this example, the script will send notifications attached to this reservation to both `top-level.url` and `my-special.url`.
+```json
+{
+    "notification_urls": "https://top-level.url",
+    "reservations": [
+        {
+            "confirmationNumber": "num1",
+            "firstName": "John",
+            "lastName": "Doe",
+            "notification_urls": "https://my-special.url"
+        }
+    ]
+}
+```
+
+
 
 [0]: https://github.com/caronc/apprise
 [1]: https://github.com/caronc/apprise#supported-notifications

--- a/README.md
+++ b/README.md
@@ -106,9 +106,6 @@ To use the default configuration file, copy `config.example.json` to `config.jso
 
 For information on how to set up the configuration, see [Configuration.md](CONFIGURATION.md)
 
-**Note**: If you are using Docker, make sure to rebuild the container after editing the configuration
-file for your changes to be applied.
-
 ## Troubleshooting
 To troubleshoot a problem, run the script with the `--verbose` flag. This will display debug messages so you can
 get a better overview of the problem.

--- a/lib/config.py
+++ b/lib/config.py
@@ -14,13 +14,16 @@ CONFIG_FILE_NAME = "config.json"
 logger = get_logger(__name__)
 
 
+# A custom exception for type or value errors in the configuration file
+class ConfigError(Exception):
+    pass
+
+
 class Config:
-    def __init__(self):
+    def __init__(self) -> None:
         # Default values are set
-        self.accounts = []
         self.check_fares = False
         self.chrome_version = None
-        self.reservations = []
         self.notification_level = NotificationLevel.INFO
         self.notification_urls = []
         self.retrieval_interval = 24 * 60 * 60
@@ -28,14 +31,95 @@ class Config:
         # _CHROMEDRIVER_PATH is set in the Docker container
         self.chromedriver_path = os.getenv("_CHROMEDRIVER_PATH", None)
 
-        # Set the configuration values if provided
+    def create(self, config_json: JSON, global_config: "GlobalConfig") -> None:
+        self._merge_globals(global_config)
+        self._parse_config(config_json)
+
+    def _merge_globals(self, global_config: "GlobalConfig") -> None:
+        self.check_fares = global_config.check_fares
+        self.chrome_version = global_config.chrome_version
+        self.chromedriver_path = global_config.chromedriver_path
+        self.notification_level = global_config.notification_level
+        self.notification_urls.extend(global_config.notification_urls)
+        self.retrieval_interval = global_config.retrieval_interval
+
+    def _parse_config(self, config: JSON) -> None:
+        if "check_fares" in config:
+            self.check_fares = config["check_fares"]
+            logger.debug("Setting check fares to %s", self.check_fares)
+
+            if not isinstance(self.check_fares, bool):
+                raise ConfigError("'check_fares' must be a boolean")
+
+        if "notification_level" in config:
+            notification_level = config["notification_level"]
+            try:
+                self.notification_level = NotificationLevel(notification_level)
+            except ValueError:
+                raise ConfigError(f"'{notification_level}' is not a valid notification level")
+
+            logger.debug("Setting notification level to %s", self.notification_level.__repr__())
+
+        if "notification_urls" in config:
+            notification_urls = config["notification_urls"]
+
+            if not isinstance(notification_urls, (list, str)):
+                raise ConfigError("'notification_urls' must be a list or string")
+
+            if isinstance(notification_urls, str) and len(notification_urls) > 0:
+                notification_urls = [notification_urls]
+
+            self.notification_urls.extend(notification_urls)
+            logger.debug("Using %d notification services", len(self.notification_urls))
+
+        if "retrieval_interval" in config:
+            self.retrieval_interval = config["retrieval_interval"]
+            logger.debug("Setting retrieval interval to %s hours", self.retrieval_interval)
+
+            if not isinstance(self.retrieval_interval, int):
+                raise ConfigError("'retrieval_interval' must be an integer")
+
+            if self.retrieval_interval < 0:
+                logger.warning(
+                    "Setting 'retrieval_interval' to 0 hours as %s hours is too low",
+                    self.retrieval_interval,
+                )
+                self.retrieval_interval = 0
+
+            # Convert hours to seconds
+            self.retrieval_interval *= 3600
+
+
+class GlobalConfig(Config):
+    def __init__(self) -> None:
+        super().__init__()
+        self.accounts = []
+        self.reservations = []
+
+    def initialize(self) -> JSON:
+        logger.debug("Initializing configuration file")
+
         try:
             config = self._read_config()
             self._parse_config(config)
-        except (TypeError, json.decoder.JSONDecodeError) as err:
+        except (ConfigError, json.decoder.JSONDecodeError) as err:
             print("Error in configuration file:")
             print(err)
             sys.exit(1)
+
+    def create_account_config(self, accounts: List[JSON]) -> None:
+        logger.debug("Creating configurations for %d accounts", len(accounts))
+        for account_json in accounts:
+            account_config = AccountConfig()
+            account_config.create(account_json, self)
+            self.accounts.append(account_config)
+
+    def create_reservation_config(self, reservations: List[JSON]) -> None:
+        logger.debug("Creating configurations for %d reservations", len(reservations))
+        for reservation_json in reservations:
+            reservation_config = ReservationConfig()
+            reservation_config.create(reservation_json, self)
+            self.reservations.append(reservation_config)
 
     def _read_config(self) -> JSON:
         project_dir = Path(__file__).parents[1]
@@ -48,124 +132,86 @@ class Config:
             logger.debug("No configuration file found. Using defaults")
             config = {}
 
+        if not isinstance(config, dict):
+            raise ConfigError("Configuration must be a JSON dictionary")
+
         return config
 
-    # This method ensures the configuration values are correct and the right types.
-    # Defaults are already set in the constructor to ensure a value is never null.
     def _parse_config(self, config: JSON) -> None:
-        if "accounts" in config:
-            accounts = config["accounts"]
-
-            if not isinstance(accounts, list):
-                raise TypeError("'accounts' must be a list")
-
-            self._parse_accounts(accounts)
-
-        if "check_fares" in config:
-            self.check_fares = config["check_fares"]
-            logger.debug("Setting check fares to %s", self.check_fares)
-
-            if not isinstance(self.check_fares, bool):
-                raise TypeError("'check_fares' must be a boolean")
+        super()._parse_config(config)
 
         if "chrome_version" in config:
             self.chrome_version = config["chrome_version"]
             logger.debug("Setting chrome version to %s", self.chrome_version)
 
             if not isinstance(self.chrome_version, int):
-                raise TypeError("'chrome_version' must be an integer")
+                raise ConfigError("'chrome_version' must be an integer")
 
         if "chromedriver_path" in config:
             self.chromedriver_path = config["chromedriver_path"]
             logger.debug("Setting custom Chromedriver path")
 
             if not isinstance(self.chromedriver_path, str):
-                raise TypeError("'chromedriver_path' must be a string")
+                raise ConfigError("'chromedriver_path' must be a string")
 
-        if "flights" in config:
-            logger.warning(
-                "The 'flights' key in the configuration file is deprecated. Use 'reservations' "
-                "instead. See CONFIGURATION.md#reservations"
-            )
-            if "reservations" not in config:
-                config["reservations"] = config["flights"]
+        if "accounts" in config:
+            accounts = config["accounts"]
 
-        if "notification_level" in config:
-            self.notification_level = config["notification_level"]
-            logger.debug("Setting notification level to %s", self.notification_level)
+            if not isinstance(accounts, list):
+                raise ConfigError("'accounts' must be a list")
 
-            if not isinstance(self.notification_level, int):
-                raise TypeError("'notification_level' must be an integer")
-
-        if "notification_urls" in config:
-            self.notification_urls = config["notification_urls"]
-
-            if not isinstance(self.notification_urls, (list, str)):
-                raise TypeError("'notification_urls' must be a list or string")
-
-            notification_urls_len = (
-                len(self.notification_urls) if isinstance(self.notification_urls, list) else 1
-            )
-            logger.debug("Using %d notification services", notification_urls_len)
+            self.create_account_config(accounts)
 
         if "reservations" in config:
             reservations = config["reservations"]
 
             if not isinstance(reservations, list):
-                raise TypeError("'reservations' must be a list")
+                raise ConfigError("'reservations' must be a list")
 
-            self._parse_reservations(reservations)
+            self.create_reservation_config(reservations)
 
-        if "retrieval_interval" in config:
-            self.retrieval_interval = config["retrieval_interval"]
-            logger.debug("Setting retrieval interval to %s hours", self.retrieval_interval)
 
-            if not isinstance(self.retrieval_interval, int):
-                raise TypeError("'retrieval_interval' must be an integer")
+class AccountConfig(Config):
+    def __init__(self) -> None:
+        super().__init__()
+        self.username = None
+        self.password = None
+        self.first_name = None
+        self.last_name = None
 
-            if self.retrieval_interval < 0:
-                logger.warning(
-                    "Setting 'retrieval_interval' to 1 hour as %s hours is too low",
-                    self.retrieval_interval,
-                )
-                self.retrieval_interval = 1
+    def _parse_config(self, config: JSON) -> None:
+        super()._parse_config(config)
 
-            # Convert hours to seconds
-            self.retrieval_interval *= 60 * 60
-
-    def _parse_accounts(self, account_config: List[JSON]) -> None:
-        logger.debug("Adding %d accounts from the configuration file", len(account_config))
         keys = ["username", "password"]
-        accounts = self._parse_objects(account_config, keys, "account")
-        self.accounts.extend(accounts)
-
-    def _parse_reservations(self, reservation_config: List[JSON]) -> None:
-        logger.debug("Adding %d reservations from the configuration file", len(reservation_config))
-        keys = ["confirmationNumber", "firstName", "lastName"]
-        reservations = self._parse_objects(reservation_config, keys, "reservation")
-        self.reservations.extend(reservations)
-
-    def _parse_objects(self, objs: List[JSON], keys: List[str], obj_type: str) -> List[List[str]]:
-        parsed_objects = []
-        for obj in objs:
-            if not isinstance(obj, dict):
-                raise TypeError(f"'{obj_type}s' must only contain dictionaries")
-
-            parsed_object = self._parse_object(obj, keys, obj_type)
-            parsed_objects.append(parsed_object)
-
-        return parsed_objects
-
-    def _parse_object(self, obj: JSON, keys: List[str], obj_type: str) -> List[str]:
-        object_info = []
         for key in keys:
-            value = obj.get(key)
-            if value is None:
-                raise TypeError(f"'{key}' must be in every {obj_type}")
+            if key not in config:
+                raise ConfigError(f"'{key}' must be in every account")
 
-            if not isinstance(value, str):
-                raise TypeError(f"'{key}' must be a string")
+            if not isinstance(config[key], str):
+                raise ConfigError(f"'{key}' in account must be a string")
 
-            object_info.append(value)
+        self.username = config["username"]
+        self.password = config["password"]
 
-        return object_info
+
+class ReservationConfig(Config):
+    def __init__(self) -> None:
+        super().__init__()
+        self.confirmation_number = None
+        self.first_name = None
+        self.last_name = None
+
+    def _parse_config(self, config: JSON) -> None:
+        super()._parse_config(config)
+
+        keys = ["confirmationNumber", "firstName", "lastName"]
+        for key in keys:
+            if key not in config:
+                raise ConfigError(f"'{key}' must be in every reservation")
+
+            if not isinstance(config[key], str):
+                raise ConfigError(f"'{key}' in reservation must be a string")
+
+        self.confirmation_number = config["confirmationNumber"]
+        self.first_name = config["firstName"]
+        self.last_name = config["lastName"]

--- a/lib/config.py
+++ b/lib/config.py
@@ -36,6 +36,11 @@ class Config:
         self._parse_config(config_json)
 
     def _merge_globals(self, global_config: "GlobalConfig") -> None:
+        """
+        Each account and reservation config inherits the global
+        configuration first. If specific options are set for an account
+        or reservation, those will override the global configuration.
+        """
         self.check_fares = global_config.check_fares
         self.chrome_version = global_config.chrome_version
         self.chromedriver_path = global_config.chromedriver_path
@@ -44,6 +49,10 @@ class Config:
         self.retrieval_interval = global_config.retrieval_interval
 
     def _parse_config(self, config: JSON) -> None:
+        """
+        Ensures every configuration option is valid. Raises a ConfigError when
+        invalid values are found.
+        """
         if "check_fares" in config:
             self.check_fares = config["check_fares"]
             logger.debug("Setting check fares to %s", self.check_fares)
@@ -66,6 +75,7 @@ class Config:
             if not isinstance(notification_urls, (list, str)):
                 raise ConfigError("'notification_urls' must be a list or string")
 
+            # Make sure that empty strings don't get added to the list
             if isinstance(notification_urls, str) and len(notification_urls) > 0:
                 notification_urls = [notification_urls]
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, List
 from lib import log
 
 if TYPE_CHECKING:
-    from lib.config import Config
+    from lib.config import GlobalConfig
 
 __version__ = "v4.3"
 
@@ -52,30 +52,27 @@ def check_flags(arguments: List[str]) -> None:
         sys.exit()
 
 
-def set_up_accounts(config: Config) -> None:
+def set_up_accounts(config: GlobalConfig) -> None:
     # pylint:disable=import-outside-toplevel
     from .reservation_monitor import AccountMonitor
 
     for account in config.accounts:
-        account_monitor = AccountMonitor(config, account[0], account[1])
+        account_monitor = AccountMonitor(account)
 
         # Start each account monitor in a separate process to run them in parallel
         process = Process(target=account_monitor.monitor)
         process.start()
 
 
-def set_up_reservations(config: Config) -> None:
+def set_up_reservations(config: GlobalConfig) -> None:
     # pylint:disable=import-outside-toplevel
     from .reservation_monitor import ReservationMonitor
 
     for reservation in config.reservations:
-        reservation_monitor = ReservationMonitor(config, reservation[1], reservation[2])
+        reservation_monitor = ReservationMonitor(reservation)
 
         # Start each reservation monitor in a separate process to run them in parallel
-        process = Process(
-            target=reservation_monitor.monitor,
-            args=([{"confirmationNumber": reservation[0]}],),
-        )
+        process = Process(target=reservation_monitor.monitor)
         process.start()
 
 
@@ -89,10 +86,11 @@ def set_up_check_in(arguments: List[str]) -> None:
     # Imported here to avoid needing dependencies to retrieve the script's
     # version or usage
     # pylint:disable=import-outside-toplevel
-    from .config import Config
+    from .config import GlobalConfig
     from .reservation_monitor import ReservationMonitor
 
-    config = Config()
+    config = GlobalConfig()
+    config.initialize()
 
     if "--test-notifications" in arguments:
         reservation_monitor = ReservationMonitor(config)
@@ -101,10 +99,16 @@ def set_up_check_in(arguments: List[str]) -> None:
         reservation_monitor.notification_handler.send_notification("This is a test message")
         sys.exit()
     elif len(arguments) == 2:
-        config.accounts.append([arguments[0], arguments[1]])
+        account = {"username": arguments[0], "password": arguments[1]}
+        config.create_account_config([account])
         logger.debug("Account added through CLI arguments")
     elif len(arguments) == 3:
-        config.reservations.append([arguments[0], arguments[1], arguments[2]])
+        reservation = {
+            "confirmationNumber": arguments[0],
+            "firstName": arguments[1],
+            "lastName": arguments[2],
+        }
+        config.create_reservation_config([reservation])
         logger.debug("Reservation added through CLI arguments")
     elif len(arguments) > 3:
         logger.error("Invalid arguments. For more information, try '--help'")

--- a/tests/test_fare_checker.py
+++ b/tests/test_fare_checker.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 import pytest
 from pytest_mock import MockerFixture
 
-from lib.config import Config
+from lib.config import ReservationConfig
 from lib.fare_checker import BOOKING_URL, FareChecker
 from lib.flight import Flight
 from lib.notification_handler import NotificationHandler
@@ -14,12 +14,6 @@ from lib.utils import FlightChangeError
 # pylint: disable=protected-access
 
 JSON = Dict[str, Any]
-
-
-# Don't read the config file
-@pytest.fixture(autouse=True)
-def mock_config(mocker: MockerFixture) -> None:
-    mocker.patch.object(Config, "_read_config")
 
 
 @pytest.fixture
@@ -43,7 +37,7 @@ def test_check_flight_price_sends_notification_on_lower_fares(
     mocker.patch.object(FareChecker, "_get_flight_price", return_value=flight_price)
     mock_lower_fare_notification = mocker.patch.object(NotificationHandler, "lower_fare")
 
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     fare_checker.check_flight_price("test_flight")
 
     mock_lower_fare_notification.assert_called_once()
@@ -58,7 +52,7 @@ def test_check_flight_price_does_not_send_notifications_when_fares_are_higher(
     mocker.patch.object(FareChecker, "_get_flight_price", return_value=flight_price)
     mock_lower_fare_notification = mocker.patch.object(NotificationHandler, "lower_fare")
 
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     fare_checker.check_flight_price("test_flight")
 
     mock_lower_fare_notification.assert_not_called()
@@ -78,7 +72,7 @@ def test_get_flight_price_gets_flight_price_matching_current_flight(
 
     test_flight.local_departure_time = "11:30"
     test_flight.local_arrival_time = "13:30"
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     price = fare_checker._get_flight_price(test_flight)
 
     assert price == "price"
@@ -94,7 +88,7 @@ def test_get_flight_price_returns_nothing_when_no_matching_flights_appear(
     mocker.patch.object(FareChecker, "_get_matching_flights", return_value=(flights, "test_fare"))
 
     test_flight.local_departure_time = "12:00"
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     price = fare_checker._get_flight_price(test_flight)
 
     assert price is None
@@ -120,7 +114,7 @@ def test_get_matching_flights_retrieves_correct_bound_page(
     response = {"changeShoppingPage": {"flights": {f"{bound}Page": {"cards": "test_cards"}}}}
     mocker.patch("lib.fare_checker.make_request", return_value=response)
 
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     matching_flights, fare_type = fare_checker._get_matching_flights(None)
 
     assert matching_flights == "test_cards"
@@ -142,7 +136,7 @@ def test_get_change_flight_page_retrieves_change_flight_page(
     )
     mock_check_for_companion = mocker.patch.object(FareChecker, "_check_for_companion")
 
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     change_flight_page, fare_type_bounds = fare_checker._get_change_flight_page(test_flight)
 
     mock_check_for_companion.assert_called_once()
@@ -166,7 +160,7 @@ def test_get_change_flight_page_raises_exception_when_flight_cannot_be_changed(
     }
     mocker.patch("lib.fare_checker.make_request", return_value=reservation_info)
 
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     with pytest.raises(FlightChangeError):
         fare_checker._get_change_flight_page(test_flight)
 
@@ -184,7 +178,7 @@ def test_get_search_query_returns_the_correct_query_for_one_way(test_flight: Fli
     }
 
     test_flight.local_departure_time = "12:00"
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     search_query = fare_checker._get_search_query(flight_page, test_flight)
 
     assert len(search_query) == 1
@@ -220,7 +214,7 @@ def test_get_search_query_returns_the_correct_query_for_round_trip(test_flight: 
     }
 
     test_flight.local_departure_time = "1:00"
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     search_query = fare_checker._get_search_query(flight_page, test_flight)
 
     assert len(search_query) == 2
@@ -250,7 +244,7 @@ def test_check_for_companion_raises_exception_when_a_companion_is_detected() -> 
         }
     }
 
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     with pytest.raises(FlightChangeError):
         fare_checker._check_for_companion(reservation_info)
 
@@ -260,7 +254,7 @@ def test_check_for_companion_raises_exception_when_a_companion_is_detected() -> 
     [{"greyBoxMessage": None}, {"greyBoxMessage": {}}, {"greyBoxMessage": {"body": ""}}],
 )
 def test_check_for_companion_passes_when_no_companion_exists(reservation: JSON) -> None:
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     # It will throw an exception if the test does not pass
     fare_checker._check_for_companion(reservation)
 
@@ -270,7 +264,7 @@ def test_get_matching_fare_returns_the_correct_fare() -> None:
         {"_meta": {"fareProductId": "wrong_fare"}, "priceDifference": "fake_price"},
         {"_meta": {"fareProductId": "right_fare"}, "priceDifference": "price"},
     ]
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     fare_price = fare_checker._get_matching_fare(fares, "right_fare")
     assert fare_price == "price"
 
@@ -279,19 +273,19 @@ def test_get_matching_fare_returns_the_correct_fare() -> None:
 def test_get_matching_fare_returns_default_price_when_price_is_not_available(
     fares: List[JSON],
 ) -> None:
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     fare_price = fare_checker._get_matching_fare(fares, "right_fare")
     assert fare_price == {"amount": "0", "currencyCode": "USD"}
 
 
 def test_get_matching_fare_raises_exception_when_fare_does_not_exist() -> None:
     fares = [{"_meta": {"fareProductId": "wrong_fare"}}]
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     with pytest.raises(KeyError):
         fare_checker._get_matching_fare(fares, "right_fare")
 
 
 def test_unavailable_fare_returns_default_price() -> None:
-    fare_checker = FareChecker(ReservationMonitor(Config()))
+    fare_checker = FareChecker(ReservationMonitor(ReservationConfig()))
     fare_price = fare_checker._unavailable_fare("fare")
     assert fare_price == {"amount": "0", "currencyCode": "USD"}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,14 +6,14 @@ import pytest
 from pytest_mock import MockerFixture
 
 from lib import main
-from lib.config import Config
+from lib.config import AccountConfig, GlobalConfig, ReservationConfig
 from lib.notification_handler import NotificationHandler
 
 
 # We don't actually want the config to read the file for these tests
 @pytest.fixture(autouse=True)
 def mock_config(mocker: MockerFixture) -> None:
-    mocker.patch("lib.config.Config._read_config")
+    mocker.patch("lib.config.GlobalConfig._read_config")
 
 
 def test_print_version_prints_script_version(capsys: pytest.CaptureFixture[str]) -> None:
@@ -63,8 +63,8 @@ def test_check_flags_does_not_exit_when_flags_are_not_matched(
 
 
 def test_set_up_accounts_starts_all_accounts_in_proceses(mocker: MockerFixture) -> None:
-    config = Config()
-    config.accounts = [["user1", "pass1"], ["user2", "pass2"]]
+    config = GlobalConfig()
+    config.accounts = [AccountConfig(), AccountConfig()]
 
     mock_process = mocker.patch("lib.main.Process")
     mock_process.start = mock.Mock()
@@ -76,8 +76,8 @@ def test_set_up_accounts_starts_all_accounts_in_proceses(mocker: MockerFixture) 
 
 
 def test_set_up_reservations_starts_all_reservations_in_proceses(mocker: MockerFixture) -> None:
-    config = Config()
-    config.reservations = [["test1", "first1", "last1"], ["test2", "first2", "last2"]]
+    config = GlobalConfig()
+    config.reservations = [ReservationConfig(), ReservationConfig()]
 
     mock_process = mocker.patch("lib.main.Process")
     mock_process.start = mock.Mock()

--- a/tests/test_reservation_monitor.py
+++ b/tests/test_reservation_monitor.py
@@ -4,7 +4,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from lib.checkin_scheduler import CheckInScheduler
-from lib.config import Config
+from lib.config import AccountConfig, ReservationConfig
 from lib.fare_checker import FareChecker
 from lib.notification_handler import NotificationHandler
 from lib.reservation_monitor import TOO_MANY_REQUESTS_CODE, AccountMonitor, ReservationMonitor
@@ -15,12 +15,6 @@ from lib.webdriver import WebDriver
 # pylint: disable=protected-access
 
 
-# Don't read the config file
-@pytest.fixture(autouse=True)
-def mock_config(mocker: MockerFixture) -> None:
-    mocker.patch("lib.reservation_monitor.Config._read_config")
-
-
 def test_reservation_monitor_monitors_reservations_continuously(mocker: MockerFixture) -> None:
     # Since the monitor function runs in an infinite loop, throw an Exception when the
     # sleep function is called a second time to break out of the loop.
@@ -29,15 +23,19 @@ def test_reservation_monitor_monitors_reservations_continuously(mocker: MockerFi
     mock_schedule_reservations = mocker.patch.object(ReservationMonitor, "_schedule_reservations")
     mock_check_flight_fares = mocker.patch.object(ReservationMonitor, "_check_flight_fares")
 
-    test_monitor = ReservationMonitor(Config())
+    config = ReservationConfig()
+    config.confirmation_number = "test_num"
+    test_monitor = ReservationMonitor(config)
     test_monitor.checkin_scheduler.flights = ["test_flight"]
 
     with pytest.raises(KeyboardInterrupt):
-        test_monitor.monitor([{"test": "flight"}])
+        test_monitor.monitor()
 
     assert mock_refresh_headers.call_count == 2
     assert mock_schedule_reservations.call_count == 2
-    mock_schedule_reservations.assert_called_with([{"test": "flight"}])
+    mock_schedule_reservations.assert_called_with(
+        [{"confirmationNumber": config.confirmation_number}]
+    )
     assert mock_check_flight_fares.call_count == 2
 
 
@@ -49,8 +47,8 @@ def test_reservation_monitor_stops_monitoring_when_no_flights_are_scheduled(
     mock_schedule_reservations = mocker.patch.object(ReservationMonitor, "_schedule_reservations")
     mock_check_flight_fares = mocker.patch.object(ReservationMonitor, "_check_flight_fares")
 
-    test_monitor = ReservationMonitor(Config())
-    test_monitor.monitor([])
+    test_monitor = ReservationMonitor(ReservationConfig())
+    test_monitor.monitor()
 
     mock_refresh_headers.assert_called_once()
     mock_schedule_reservations.assert_called_once()
@@ -66,12 +64,12 @@ def test_reservation_monitor_monitors_reservations_once_if_retrieval_interval_is
     mock_schedule_reservations = mocker.patch.object(ReservationMonitor, "_schedule_reservations")
     mock_check_flight_fares = mocker.patch.object(ReservationMonitor, "_check_flight_fares")
 
-    config = Config()
+    config = ReservationConfig()
     config.retrieval_interval = 0
     test_monitor = ReservationMonitor(config)
     test_monitor.checkin_scheduler.flights = ["test_flight"]
 
-    test_monitor.monitor([])
+    test_monitor.monitor()
 
     mock_refresh_headers.assert_called_once()
     mock_schedule_reservations.assert_called_once()
@@ -83,7 +81,7 @@ def test_reservation_monitor_schedules_reservations_correctly(mocker: MockerFixt
     mock_process_reservations = mocker.patch.object(CheckInScheduler, "process_reservations")
     reservations = [{"confirmationNumber": "Test1"}, {"confirmationNumber": "Test2"}]
 
-    test_monitor = ReservationMonitor(Config())
+    test_monitor = ReservationMonitor(ReservationConfig())
     test_monitor._schedule_reservations(reservations)
 
     mock_process_reservations.assert_called_once_with(["Test1", "Test2"])
@@ -94,7 +92,7 @@ def test_reservation_monitor_does_not_check_fares_if_configuration_is_false(
 ) -> None:
     mock_fare_checker = mocker.patch("lib.reservation_monitor.FareChecker")
 
-    test_monitor = ReservationMonitor(Config())
+    test_monitor = ReservationMonitor(ReservationConfig())
     test_monitor.config.check_fares = False
     test_monitor._check_flight_fares()
 
@@ -104,7 +102,7 @@ def test_reservation_monitor_does_not_check_fares_if_configuration_is_false(
 def test_reservation_monitor_checks_fares_on_all_flights(mocker: MockerFixture) -> None:
     mock_check_flight_price = mocker.patch.object(FareChecker, "check_flight_price")
 
-    test_monitor = ReservationMonitor(Config())
+    test_monitor = ReservationMonitor(ReservationConfig())
     test_monitor.config.check_fares = True
     test_monitor.checkin_scheduler.flights = ["test_flight1", "test_flight2"]
     test_monitor._check_flight_fares()
@@ -120,7 +118,7 @@ def test_reservation_monitor_catches_error_when_checking_fares(
         FareChecker, "check_flight_price", side_effect=["", exception]
     )
 
-    test_monitor = ReservationMonitor(Config())
+    test_monitor = ReservationMonitor(ReservationConfig())
     test_monitor.config.check_fares = True
     test_monitor.checkin_scheduler.flights = ["test_flight1", "test_flight2"]
     test_monitor._check_flight_fares()
@@ -133,7 +131,7 @@ def test_reservation_monitor_smart_sleep_sleeps_for_correct_time(mocker: MockerF
     mock_datetime = mocker.patch("lib.reservation_monitor.datetime")
     mock_datetime.utcnow.return_value = datetime(1999, 12, 31)
 
-    test_monitor = ReservationMonitor(Config())
+    test_monitor = ReservationMonitor(ReservationConfig())
     test_monitor.config.retrieval_interval = 24 * 60 * 60
     test_monitor._smart_sleep(datetime(1999, 12, 30, 12))
 
@@ -150,7 +148,7 @@ def test_account_monitor_monitors_the_account_continuously(mocker: MockerFixture
     mock_schedule_reservations = mocker.patch.object(AccountMonitor, "_schedule_reservations")
     mock_check_flight_fares = mocker.patch.object(AccountMonitor, "_check_flight_fares")
 
-    test_monitor = AccountMonitor(Config(), "", "")
+    test_monitor = AccountMonitor(AccountConfig())
 
     with pytest.raises(KeyboardInterrupt):
         test_monitor.monitor()
@@ -170,7 +168,7 @@ def test_account_monitor_skips_scheduling_on_too_many_requests_error(mocker: Moc
     mock_schedule_reservations = mocker.patch.object(AccountMonitor, "_schedule_reservations")
     mock_check_flight_fares = mocker.patch.object(AccountMonitor, "_check_flight_fares")
 
-    test_monitor = AccountMonitor(Config(), "", "")
+    test_monitor = AccountMonitor(AccountConfig())
 
     with pytest.raises(KeyboardInterrupt):
         test_monitor.monitor()
@@ -190,9 +188,9 @@ def test_account_monitor_checks_reservations_once_if_retrieval_interval_is_zero(
     mock_schedule_reservations = mocker.patch.object(AccountMonitor, "_schedule_reservations")
     mock_check_flight_fares = mocker.patch.object(AccountMonitor, "_check_flight_fares")
 
-    config = Config()
+    config = AccountConfig()
     config.retrieval_interval = 0
-    test_monitor = AccountMonitor(config, "", "")
+    test_monitor = AccountMonitor(config)
 
     test_monitor.monitor()
 
@@ -206,7 +204,7 @@ def test_get_reservations_skips_retrieval_on_too_many_requests_error(mocker: Moc
     mocker.patch.object(
         WebDriver, "get_reservations", side_effect=LoginError("", TOO_MANY_REQUESTS_CODE)
     )
-    test_monitor = AccountMonitor(Config(), "", "")
+    test_monitor = AccountMonitor(AccountConfig())
     reservations, skip_scheduling = test_monitor._get_reservations()
     assert len(reservations) == 0
     assert skip_scheduling
@@ -217,7 +215,7 @@ def test_get_reservations_exits_on_login_error(mocker: MockerFixture) -> None:
     mock_failed_login = mocker.patch.object(NotificationHandler, "failed_login")
 
     with pytest.raises(SystemExit):
-        test_monitor = AccountMonitor(Config(), "", "")
+        test_monitor = AccountMonitor(AccountConfig())
         test_monitor._get_reservations()
 
     mock_failed_login.assert_called_once()
@@ -227,7 +225,7 @@ def test_get_reservations_returns_the_correct_reservations(mocker: MockerFixture
     reservations = [{"reservation1": "test1"}, {"reservation2": "test2"}]
     mocker.patch.object(WebDriver, "get_reservations", return_value=reservations)
 
-    test_monitor = AccountMonitor(Config(), "", "")
+    test_monitor = AccountMonitor(AccountConfig())
     new_reservations, skip_scheduling = test_monitor._get_reservations()
 
     assert new_reservations == reservations


### PR DESCRIPTION
Fixes #94.

Configuration options can now be specified for individual accounts and reservations. Details on how it works can be found below as well as in the Configuration doc.

Account and reservation-specific config options will override the global configs. Here are four examples:

1. Global: check_fares is True
    Reservation: check_fares is not specified
    Outcome: check_fares is True for that reservation

2. Global: check_fares is not specified
    Reservation: check_fares is True
    Outcome: check_fares is True for that reservation

3. Global: check_fares is True
    Reservation: check_fares is False
    Outcome: check_fares is False for that reservation

4. Global: check_fares is not specified
    Reservation: check_fares is not specified
    Outcome: The default value for check_fares is applied to that reservation

Additionally, notification URLS will merge together. An account or reservation with specific notification URLs will send notifications to those URLs as well as URLs specified globally.