### PR TITLE
add a random sleep so that multiple threads don't work at the same time

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -105,6 +105,7 @@ def set_up_reservations(config: GlobalConfig) -> None:
         reservation_monitor.start()
         self._sleep("reservations")
 
+
 def _sleep(name: String) -> None:
     sleep_time = random.randint(300, 600)
     logger.debug("Sleeping between %s for %d seconds", name, sleep_time)

--- a/lib/main.py
+++ b/lib/main.py
@@ -93,6 +93,7 @@ def set_up_accounts(config: GlobalConfig) -> None:
     for account in config.accounts:
         account_monitor = AccountMonitor(account)
         account_monitor.start()
+        self._sleep("accounts")
 
 
 def set_up_reservations(config: GlobalConfig) -> None:
@@ -102,6 +103,12 @@ def set_up_reservations(config: GlobalConfig) -> None:
     for reservation in config.reservations:
         reservation_monitor = ReservationMonitor(reservation)
         reservation_monitor.start()
+        self._sleep("reservations")
+
+def _sleep(name: String) -> None:
+    sleep_time = random.randint(300, 600)
+    logger.debug("Sleeping between %s for %d seconds", name, sleep_time)
+    time.sleep(sleep_time)
 
 
 def set_up_check_in(arguments: List[str]) -> None:

--- a/lib/main.py
+++ b/lib/main.py
@@ -86,22 +86,22 @@ def test_notifications(config: GlobalConfig) -> None:
     reservation_monitor.notification_handler.send_notification("This is a test message")
 
 
-def set_up_accounts(config: GlobalConfig, lock) -> None:
+def set_up_accounts(config: GlobalConfig, lock: multiprocessing.Lock) -> None:
     # pylint:disable=import-outside-toplevel
     from .reservation_monitor import AccountMonitor
 
     for account in config.accounts:
-        account_monitor = AccountMonitor(account)
-        account_monitor.start(lock)
+        account_monitor = AccountMonitor(account, lock)
+        account_monitor.start()
 
 
-def set_up_reservations(config: GlobalConfig, lock) -> None:
+def set_up_reservations(config: GlobalConfig, lock: multiprocessing.Lock) -> None:
     # pylint:disable=import-outside-toplevel
     from .reservation_monitor import ReservationMonitor
 
     for reservation in config.reservations:
-        reservation_monitor = ReservationMonitor(reservation)
-        reservation_monitor.start(lock)
+        reservation_monitor = ReservationMonitor(reservation, lock)
+        reservation_monitor.start()
 
 
 def set_up_check_in(arguments: List[str]) -> None:
@@ -109,7 +109,7 @@ def set_up_check_in(arguments: List[str]) -> None:
     Initialize reservation and account monitoring based on the configuration
     and arguments passed in
     """
-    logger.debug(f"Auto-Southwest Check-In {__version__}")
+    logger.debug("Auto-Southwest Check-In %s", __version__)
     logger.debug("Called with %d arguments", len(arguments))
 
     # Imported here to avoid needing dependencies to retrieve the script's

--- a/lib/main.py
+++ b/lib/main.py
@@ -86,30 +86,22 @@ def test_notifications(config: GlobalConfig) -> None:
     reservation_monitor.notification_handler.send_notification("This is a test message")
 
 
-def set_up_accounts(config: GlobalConfig) -> None:
+def set_up_accounts(config: GlobalConfig, lock) -> None:
     # pylint:disable=import-outside-toplevel
     from .reservation_monitor import AccountMonitor
 
     for account in config.accounts:
         account_monitor = AccountMonitor(account)
-        account_monitor.start()
-        self._sleep("accounts")
+        account_monitor.start(lock)
 
 
-def set_up_reservations(config: GlobalConfig) -> None:
+def set_up_reservations(config: GlobalConfig, lock) -> None:
     # pylint:disable=import-outside-toplevel
     from .reservation_monitor import ReservationMonitor
 
     for reservation in config.reservations:
         reservation_monitor = ReservationMonitor(reservation)
-        reservation_monitor.start()
-        self._sleep("reservations")
-
-
-def _sleep(name: String) -> None:
-    sleep_time = random.randint(300, 600)
-    logger.debug("Sleeping between %s for %d seconds", name, sleep_time)
-    time.sleep(sleep_time)
+        reservation_monitor.start(lock)
 
 
 def set_up_check_in(arguments: List[str]) -> None:
@@ -150,8 +142,9 @@ def set_up_check_in(arguments: List[str]) -> None:
     logger.debug(
         "Monitoring %d accounts and %d reservations", len(config.accounts), len(config.reservations)
     )
-    set_up_accounts(config)
-    set_up_reservations(config)
+    lock = multiprocessing.Lock()
+    set_up_accounts(config, lock)
+    set_up_reservations(config, lock)
 
     # Keep the main process alive until all processes are done so it can handle
     # keyboard interrupts

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -1,4 +1,5 @@
 import multiprocessing
+import random
 import sys
 import time
 from datetime import datetime
@@ -51,6 +52,11 @@ class ReservationMonitor:
 
         while True:
             time_before = datetime.utcnow()
+
+            # Sleep for a random amount of time so that each thread isn't operating at the same time.
+            sleep_time = random.randint(1, 240)
+            logger.debug("Sleeping for %d seconds", sleep_time)
+            time.sleep(sleep_time)
 
             # Ensure we have valid headers
             self.checkin_scheduler.refresh_headers()
@@ -153,6 +159,12 @@ class AccountMonitor(ReservationMonitor):
         """
         while True:
             time_before = datetime.utcnow()
+
+            # Sleep for a random amount of time so that each thread isn't operating at the same time.
+            sleep_time = random.randint(1, 240)
+            logger.debug("Sleeping for %d seconds", sleep_time)
+            time.sleep(sleep_time)
+
             reservations, skip_scheduling = self._get_reservations()
 
             if not skip_scheduling:

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -153,7 +153,6 @@ class AccountMonitor(ReservationMonitor):
         """
         while True:
             time_before = datetime.utcnow()
-
             reservations, skip_scheduling = self._get_reservations()
 
             if not skip_scheduling:

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -1,5 +1,4 @@
 import multiprocessing
-import random
 import sys
 import time
 from datetime import datetime
@@ -53,9 +52,6 @@ class ReservationMonitor:
         while True:
             time_before = datetime.utcnow()
 
-            # Prevent each thread from running at the same time as another thread.
-            self._randomly_sleep()
-
             # Ensure we have valid headers
             self.checkin_scheduler.refresh_headers()
 
@@ -98,14 +94,6 @@ class ReservationMonitor:
                 logger.debug("%s. Skipping fare check", err)
             except Exception as err:
                 logger.exception("Unexpected error during fare check: %s", repr(err))
-
-    def _randomly_sleep(self) -> None:
-        """
-        Sleep for a random amount of time so that each thread isn't operating at the same time.
-        """
-        sleep_time = random.randint(1, 240)
-        logger.debug("Sleeping for %d seconds", sleep_time)
-        time.sleep(sleep_time)
 
     def _smart_sleep(self, previous_time: datetime) -> None:
         """
@@ -165,9 +153,6 @@ class AccountMonitor(ReservationMonitor):
         """
         while True:
             time_before = datetime.utcnow()
-
-            # Prevent each thread from running at the same time as another thread.
-            self._randomly_sleep()
 
             reservations, skip_scheduling = self._get_reservations()
 

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -53,10 +53,8 @@ class ReservationMonitor:
         while True:
             time_before = datetime.utcnow()
 
-            # Sleep for a random amount of time so that each thread isn't operating at the same time.
-            sleep_time = random.randint(1, 240)
-            logger.debug("Sleeping for %d seconds", sleep_time)
-            time.sleep(sleep_time)
+            # Prevent each thread from running at the same time as another thread.
+            self._randomly_sleep()
 
             # Ensure we have valid headers
             self.checkin_scheduler.refresh_headers()
@@ -100,6 +98,14 @@ class ReservationMonitor:
                 logger.debug("%s. Skipping fare check", err)
             except Exception as err:
                 logger.exception("Unexpected error during fare check: %s", repr(err))
+
+    def _randomly_sleep(self) -> None:
+        """
+        Sleep for a random amount of time so that each thread isn't operating at the same time.
+        """
+        sleep_time = random.randint(1, 240)
+        logger.debug("Sleeping for %d seconds", sleep_time)
+        time.sleep(sleep_time)
 
     def _smart_sleep(self, previous_time: datetime) -> None:
         """
@@ -160,10 +166,8 @@ class AccountMonitor(ReservationMonitor):
         while True:
             time_before = datetime.utcnow()
 
-            # Sleep for a random amount of time so that each thread isn't operating at the same time.
-            sleep_time = random.randint(1, 240)
-            logger.debug("Sleeping for %d seconds", sleep_time)
-            time.sleep(sleep_time)
+            # Prevent each thread from running at the same time as another thread.
+            self._randomly_sleep()
 
             reservations, skip_scheduling = self._get_reservations()
 

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -23,26 +23,31 @@ class ReservationMonitor:
     check-ins, flight changes or cancellations, and lower flight fares.
     """
 
-    def __init__(self, config: Config) -> None:
+    def __init__(self, config: Config, lock: multiprocessing.Lock = None) -> None:
         self.first_name = config.first_name
         self.last_name = config.last_name
 
         self.config = config
+        self.lock = lock
         self.notification_handler = NotificationHandler(self)
         self.checkin_scheduler = CheckInScheduler(self)
 
-    def start(self, lock) -> None:
+    def start(self) -> None:
         """Start each reservation monitor in a separate process to run them in parallel"""
-        process = multiprocessing.Process(target=self.monitor, args=(lock,))
+        process = multiprocessing.Process(target=self.monitor)
         process.start()
 
-    def monitor(self, lock) -> None:
+    def monitor(self) -> None:
         try:
-            self._monitor(lock)
+            self._monitor()
         except KeyboardInterrupt:
-            self._stop_monitoring()
+            # Add a small delay so the MainThread's message prints first
+            time.sleep(0.05)
+            # Lock so all processes are stopped sequentially
+            with self.lock:
+                self._stop_monitoring()
 
-    def _monitor(self, lock) -> None:
+    def _monitor(self) -> None:
         """
         Check for reservation changes and lower fares every X hours (retrieval interval).
         Will exit when no more flights are scheduled for check-in.
@@ -51,9 +56,11 @@ class ReservationMonitor:
 
         while True:
             time_before = datetime.utcnow()
+
             logger.debug("Acquiring lock...")
-            with lock:
+            with self.lock:
                 logger.debug("Lock acquired")
+
                 # Ensure we have valid headers
                 self.checkin_scheduler.refresh_headers()
 
@@ -69,7 +76,8 @@ class ReservationMonitor:
                 if self.config.retrieval_interval <= 0:
                     logger.debug("Reservation monitoring is disabled as retrieval interval is 0")
                     break
-            logger.debug("Lock released.")
+
+            logger.debug("Lock released")
             self._smart_sleep(time_before)
 
     def _schedule_reservations(self, reservations: List[Dict[str, Any]]) -> None:
@@ -108,18 +116,6 @@ class ReservationMonitor:
         logger.debug("Sleeping for %d seconds", sleep_time)
         time.sleep(sleep_time)
 
-    def _wait_to_stop(self) -> None:
-        """
-        In order to print ordered information when Ctrl-C is pressed, each monitor
-        will wait for a different amount of time (based on the process name).
-        """
-        # Get the process number that is part of its name (e.g. 'Process-1' -> '1')
-        process_name = multiprocessing.current_process().name
-        process_num = process_name.partition("-")[2]
-
-        sleep_time = int(process_num) * 0.1
-        time.sleep(sleep_time)
-
     def _stop_checkins(self) -> None:
         """
         Stops all check-ins for a monitor. This is called when Ctrl-C is pressed. The
@@ -133,7 +129,6 @@ class ReservationMonitor:
             checkin.stop_check_in()
 
     def _stop_monitoring(self) -> None:
-        self._wait_to_stop()
         print(
             f"\nStopping monitoring for reservation with confirmation number "
             f"{self.config.confirmation_number} and name {self.first_name} {self.last_name}"
@@ -144,20 +139,21 @@ class ReservationMonitor:
 class AccountMonitor(ReservationMonitor):
     """Monitor an account for newly booked reservations"""
 
-    def __init__(self, config: AccountConfig) -> None:
-        super().__init__(config)
+    def __init__(self, config: AccountConfig, lock: multiprocessing.Lock) -> None:
+        super().__init__(config, lock)
         self.username = config.username
         self.password = config.password
 
-    def _monitor(self, lock) -> None:
+    def _monitor(self) -> None:
         """
         Check for newly booked reservations for the account every X hours (retrieval interval).
         """
         while True:
             time_before = datetime.utcnow()
+
             logger.debug("Acquiring lock...")
-            with lock:
-                logger.debug("Lock acquired.")
+            with self.lock:
+                logger.debug("Lock acquired")
                 reservations, skip_scheduling = self._get_reservations()
 
                 if not skip_scheduling:
@@ -168,7 +164,7 @@ class AccountMonitor(ReservationMonitor):
                     logger.debug("Account monitoring is disabled as retrieval interval is 0")
                     break
 
-            logger.debug("Lock released.")
+            logger.debug("Lock released")
             self._smart_sleep(time_before)
 
     def _get_reservations(self) -> Tuple[List[Dict[str, Any]], bool]:
@@ -202,6 +198,5 @@ class AccountMonitor(ReservationMonitor):
         return reservations, False
 
     def _stop_monitoring(self) -> None:
-        self._wait_to_stop()
         print(f"\nStopping monitoring for account with username {self.username}")
         self._stop_checkins()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,7 @@ exclude_lines = [
 filterwarnings = [
     # Currently used by Apprise. Remove once Apprise removes it for Python 3.11+
     'ignore:Use setlocale\(\), getencoding\(\) and getlocale\(\) instead:DeprecationWarning',
+
+    # Currently used by Selenium Wire. Remove once Selenium Wire removes it
+    'ignore:pkg_resources is deprecated as an API:DeprecationWarning'
 ]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,7 +89,7 @@ def test_set_up_accounts_starts_all_accounts(mocker: MockerFixture) -> None:
     config.accounts = [AccountConfig(), AccountConfig()]
 
     mock_account_start = mocker.patch.object(AccountMonitor, "start")
-    main.set_up_accounts(config)
+    main.set_up_accounts(config, None)
     assert mock_account_start.call_count == len(config.accounts)
 
 
@@ -98,7 +98,7 @@ def test_set_up_reservations_starts_all_reservations(mocker: MockerFixture) -> N
     config.reservations = [ReservationConfig(), ReservationConfig()]
 
     mock_reservation_start = mocker.patch.object(ReservationMonitor, "start")
-    main.set_up_reservations(config)
+    main.set_up_reservations(config, None)
     assert mock_reservation_start.call_count == len(config.reservations)
 
 


### PR DESCRIPTION
First off - thanks for making this tool. I'm pretty excited about it.

I have a few accounts set up where I'm running this, and I've noticed that occasionally one of the accounts will get a failure on startup. Unfortunately I don't have the logs because I've been testing this and the logs have rolled over. Sorry about that.

I suspected that this was occurring because each thread of `reservation_monitor` was running at the same time, which Southwest would likely be suspicious of. I added this random sleep to the `reservation_monitor` logic to try to make this more "human-like".

A couple of notes/concerns here:

- I did not discuss this with you before implementing this change, so consider this my "discussion". Though I am running this code myself and it appears to be working nicely.
- I don't think this will impact the actual check-in logic processing at the right time, but I would like your confirmation on that.
- It has been a long time since I've written any python, so any feedback on that front would be welcome (or any feedback at all).
- Maybe this should be configurable using a setting in the json config file? I can't come up with a good reason you'd want to turn this off but nevertheless.
- This sleep is not really needed if there is only one thread running, but I'm not sure the best way to determine that.