### PR TITLE
fix form-urlencoding for passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ When upgrading to a new version, make sure to follow the directions under the "U
 If there is no "Upgrading" header for that version, no post-upgrade actions need to be performed.
 
 
-### Upcoming
+## 5.0 (2023-08-04)
 
 ### New Features
 - Account and reservation-specific configurations are now supported. See

--- a/lib/main.py
+++ b/lib/main.py
@@ -11,7 +11,7 @@ from lib import log
 if TYPE_CHECKING:
     from lib.config import GlobalConfig
 
-__version__ = "v4.3"
+__version__ = "v5.0"
 
 __doc__ = """
 Schedule a check-in:

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -6,6 +6,7 @@ import re
 import time
 from typing import TYPE_CHECKING, Any, Dict, List
 
+from requests.compat import quote_plus
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
@@ -103,7 +104,9 @@ class WebDriver:
         password_element = WebDriverWait(driver, 30).until(
             EC.presence_of_element_located((By.NAME, "password"))
         )
-        password_element.send_keys(account_monitor.password)
+
+        # Use quote_plus to workaround a x-www-form-urlencoded encoding bug on the mobile site
+        password_element.send_keys(quote_plus(account_monitor.password))
         password_element.submit()
 
         response = self._wait_for_response(driver, 0)

--- a/tests/test_webdriver.py
+++ b/tests/test_webdriver.py
@@ -21,7 +21,10 @@ def mock_driver(mocker: MockerFixture) -> mock.Mock:
 
 @pytest.fixture
 def mock_reservation_monitor(mocker: MockerFixture) -> mock.Mock:
-    return mocker.patch("lib.reservation_monitor.AccountMonitor")
+    mock = mocker.patch("lib.reservation_monitor.AccountMonitor")
+    mock.username = "default_user"
+    mock.password = "some-password"
+    return mock
 
 
 @pytest.fixture


### PR DESCRIPTION
The mobile Southwest site doesn't properly encode their form submission (likely a JS bug). To work around this, we can encode the password value.

Tested with a password containing all the allowed characters except `<` and `>`. They are supposedly allowed, but current desktop UI prohibits them on password update. Used password `A1!@#$%^*();:/\` as a test.