### PR TITLE
add healthchecks.io integration

### DIFF
--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import signal
 import time
+import requests
 from datetime import datetime, timedelta
 from multiprocessing import Lock, Process
 from typing import TYPE_CHECKING
@@ -146,9 +147,14 @@ class CheckInHandler:
         except RequestError as err:
             logger.debug("Failed to check in. Error: %s. Exiting", err)
             self.notification_handler.failed_checkin(err, self.flight)
+            if self.checkin_scheduler.reservation_monitor.config.healthchecks_url is not None:
+                requests.post(self.checkin_scheduler.reservation_monitor.config.healthchecks_url + "/fail", data="Failed check in, confirmation number=" + self.flight.confirmation_number)
             return
 
         logger.debug("Successfully checked in!")
         self.notification_handler.successful_checkin(
             reservation["checkInConfirmationPage"], self.flight
         )
+        if self.checkin_scheduler.reservation_monitor.config.healthchecks_url is not None:
+            requests.post(self.checkin_scheduler.reservation_monitor.config.healthchecks_url, data="Successful check in, confirmation number=" + self.flight.confirmation_number)
+

--- a/lib/config.py
+++ b/lib/config.py
@@ -26,6 +26,7 @@ class Config:
         self.notification_level = NotificationLevel.INFO
         self.notification_urls = []
         self.retrieval_interval = 24 * 60 * 60
+        self.healthchecks_url = None
 
     def create(self, config_json: JSON, global_config: "GlobalConfig") -> None:
         self._merge_globals(global_config)
@@ -95,6 +96,10 @@ class Config:
 
             # Convert hours to seconds
             self.retrieval_interval *= 3600
+
+        if "healthchecks_url" in config:
+            self.healthchecks_url = config["healthchecks_url"]
+            logger.debug("Setting healthchecks URL to %s", self.healthchecks_url)
 
 
 class GlobalConfig(Config):
@@ -178,6 +183,7 @@ class AccountConfig(Config):
         self.password = None
         self.first_name = None
         self.last_name = None
+        self.healthchecks_url = None
 
     def _parse_config(self, config: JSON) -> None:
         super()._parse_config(config)

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import requests
+
 from typing import TYPE_CHECKING, Any, Dict, List, Tuple
 
 from .checkin_scheduler import VIEW_RESERVATION_URL
@@ -35,6 +37,8 @@ class FareChecker:
         amount = int(flight_price["amount"].replace(",", ""))
         price_info = f"{sign}{amount} {flight_price['currencyCode']}"
         logger.debug("Flight price change found for %s", price_info)
+        if self.reservation_monitor.config.healthchecks_url is not None:
+            requests.post(self.reservation_monitor.config.healthchecks_url, data="Successful fare check, confirmation number=" + flight.confirmation_number)
 
         # The Southwest website can report a fare price difference of -1 USD. This is a
         # false positive as no credit is actually received when the flight is changed.

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -1,6 +1,7 @@
 import multiprocessing
 import sys
 import time
+import requests
 from datetime import datetime
 from typing import Any, Dict, List, Tuple
 
@@ -99,10 +100,14 @@ class ReservationMonitor:
             try:
                 fare_checker.check_flight_price(flight)
             except RequestError as err:
+                if self.config.healthchecks_url is not None:
+                    requests.post(self.config.healthchecks_url + "/fail", data="Failed fare check, confirmation number=" + flight.confirmation_number)
                 logger.error("Requesting error during fare check. %s. Skipping...", err)
             except FlightChangeError as err:
                 logger.debug("%s. Skipping fare check", err)
             except Exception as err:
+                if self.config.healthchecks_url is not None:
+                    requests.post(self.config.healthchecks_url + "/fail", data="Failed fare check, confirmation number=" + flight.confirmation_number)
                 logger.exception("Unexpected error during fare check: %s", repr(err))
 
     def _smart_sleep(self, previous_time: datetime) -> None:


### PR DESCRIPTION
Creating this pull request to start a discussion before continuing the implementation.

Over the past couple months, there have been a few times where features of this app have stopped working unexpectedly. Integration with [healthchecks.io](https://healthchecks.io/) would allow more close monitoring of the app, particularly the fare check part (which is most useful to me).

Wondering if you have any thoughts on this work.

To-do/thoughts:

- [ ] The healthchecks calls around check in are likely not needed because notifications are sent when check in fails or succeeds.