### PR TITLE
Use an NTP server to fetch the current time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 When upgrading to a new version, make sure to follow the directions under the "Upgrading" header of the corresponding version.
 If there is no "Upgrading" header for that version, no post-upgrade actions need to be performed.
 
+
+## Upcoming
+### New Features
+- Times are now fetched from an NTP server when possible ([#235](https://github.com/jdholtz/auto-southwest-check-in/issues/235))
+    - This mitigates issues with the time being off on computers running the script, which may cause failed check-ins
+
+### Upgrading
+- Upgrade the dependencies to the latest versions by running `pip install -r requirements.txt`
+    - [ntplib](https://pypi.org/project/ntplib/) is a now a dependency
+
+
 ## 7.4 (2024-04-14)
 ### New Features
 - A [development container](https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers)

--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from .flight import Flight
 from .log import get_logger
-from .utils import RequestError, make_request
+from .utils import RequestError, get_current_time, make_request
 
 if TYPE_CHECKING:
     from .checkin_scheduler import CheckInScheduler
@@ -82,7 +82,7 @@ class CheckInHandler:
             pass
 
     def _wait_for_check_in(self, checkin_time: datetime) -> None:
-        current_time = datetime.utcnow()
+        current_time = get_current_time()
         if checkin_time <= current_time:
             logger.debug("Check-in time has passed. Going straight to check-in")
             return
@@ -104,7 +104,7 @@ class CheckInHandler:
 
             logger.debug("Lock released")
 
-        current_time = datetime.utcnow()
+        current_time = get_current_time()
         sleep_time = (checkin_time - current_time).total_seconds()
         logger.debug("Sleeping until check-in: %d seconds...", sleep_time)
         time.sleep(sleep_time)

--- a/lib/flight.py
+++ b/lib/flight.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 
@@ -71,7 +71,7 @@ class Flight:
         flight_date = datetime.strptime(flight_date, "%Y-%m-%d %H:%M")
         self._local_departure_time = airport_timezone.localize(flight_date)
 
-        utc_time = self._local_departure_time.astimezone(pytz.utc).replace(tzinfo=None)
+        utc_time = self._local_departure_time.astimezone(timezone.utc).replace(tzinfo=None)
         return utc_time
 
     def _get_flight_number(self, flights: JSON) -> str:

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -9,7 +9,7 @@ from .config import AccountConfig, ReservationConfig
 from .fare_checker import FareChecker
 from .log import get_logger
 from .notification_handler import NotificationHandler
-from .utils import FlightChangeError, LoginError, RequestError
+from .utils import FlightChangeError, LoginError, RequestError, get_current_time
 from .webdriver import WebDriver
 
 TOO_MANY_REQUESTS_CODE = 429
@@ -57,7 +57,7 @@ class ReservationMonitor:
         reservation = {"confirmationNumber": self.config.confirmation_number}
 
         while True:
-            time_before = datetime.utcnow()
+            time_before = get_current_time()
 
             logger.debug("Acquiring lock...")
             with self.lock:
@@ -124,7 +124,7 @@ class ReservationMonitor:
         Account for the time it took to do recurring tasks so the sleep interval
         is the exact time provided in the configuration file.
         """
-        current_time = datetime.utcnow()
+        current_time = get_current_time()
         time_taken = (current_time - previous_time).total_seconds()
         sleep_time = self.config.retrieval_interval - time_taken
         logger.debug("Sleeping for %d seconds", sleep_time)
@@ -163,7 +163,7 @@ class AccountMonitor(ReservationMonitor):
         Check for newly booked reservations for the account every X hours (retrieval interval).
         """
         while True:
-            time_before = datetime.utcnow()
+            time_before = get_current_time()
 
             logger.debug("Acquiring lock...")
             with self.lock:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 apprise==1.7.6
+ntplib==0.4.0
 pytz==2024.1  # Remove when this script only supports Python 3.9+
 requests==2.31.0
 seleniumbase==4.25.4

--- a/tests/integration/test_check_in.py
+++ b/tests/integration/test_check_in.py
@@ -37,11 +37,13 @@ def test_check_in(
     handler: CheckInHandler,
     same_day_flight: bool,
 ) -> None:
-    mock_datetime = mocker.patch("lib.checkin_handler.datetime")
-    mock_datetime.utcnow.side_effect = [
-        datetime(2021, 12, 5, 13, 40),
-        datetime(2021, 12, 5, 14, 20),
-    ]
+    mocker.patch(
+        "lib.checkin_handler.get_current_time",
+        side_effect=[
+            datetime(2021, 12, 5, 13, 40),
+            datetime(2021, 12, 5, 14, 20),
+        ],
+    )
     mock_sleep = mocker.patch("time.sleep")
 
     handler.first_name = "Garry"

--- a/tests/integration/test_monitoring_and_scheduling.py
+++ b/tests/integration/test_monitoring_and_scheduling.py
@@ -5,6 +5,7 @@ are set, errors are handled, and integration with the webdriver works.
 
 import copy
 import json
+from datetime import datetime
 from multiprocessing import Lock
 from unittest import mock
 
@@ -59,6 +60,7 @@ def test_flight_is_scheduled_checks_in_and_departs(
     tz_data = {"LAX": "America/Los_Angeles"}
 
     mocker.patch("pathlib.Path.read_text", return_value=json.dumps(tz_data))
+    mocker.patch("lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31))
     mock_process = mocker.patch("lib.checkin_handler.Process").return_value
     mock_new_flights_notification = mocker.patch(
         "lib.notification_handler.NotificationHandler.new_flights"
@@ -135,6 +137,7 @@ def test_account_schedules_new_flights(requests_mock: RequestMocker, mocker: Moc
     tz_data = {"LAX": "America/Los_Angeles", "SYD": "Australia/Sydney"}
     mocker.patch("pathlib.Path.read_text", return_value=json.dumps(tz_data))
 
+    mocker.patch("lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31))
     mocker.patch("lib.webdriver.seleniumbase_actions.wait_for_element_not_visible")
     mock_process = mocker.patch("lib.checkin_handler.Process").return_value
     # Raise a StopIteration to prevent an infinite loop

--- a/tests/unit/test_checkin_handler.py
+++ b/tests/unit/test_checkin_handler.py
@@ -79,15 +79,19 @@ class TestCheckInHandler:
         self, mocker: MockerFixture
     ) -> None:
         mock_sleep = mocker.patch("time.sleep")
-        self.handler._wait_for_check_in(datetime(1999, 12, 31))
+        mocker.patch(
+            "lib.checkin_handler.get_current_time", return_value=datetime(1999, 12, 31, 18, 30)
+        )
+        self.handler._wait_for_check_in(datetime(1999, 12, 31, 18))
         mock_sleep.assert_not_called()
 
     def test_wait_for_check_in_sleeps_once_when_check_in_is_less_than_thirty_minutes_away(
         self, mocker: MockerFixture
     ) -> None:
         mock_sleep = mocker.patch("time.sleep")
-        mock_datetime = mocker.patch("lib.checkin_handler.datetime")
-        mock_datetime.utcnow.return_value = datetime(1999, 12, 31, 18, 29, 59)
+        mocker.patch(
+            "lib.checkin_handler.get_current_time", return_value=datetime(1999, 12, 31, 18, 29, 59)
+        )
 
         self.handler._wait_for_check_in(datetime(1999, 12, 31, 18, 59, 59))
 
@@ -102,11 +106,13 @@ class TestCheckInHandler:
     ) -> None:
         mock_sleep = mocker.patch("time.sleep")
         mock_refresh_headers = self.handler.checkin_scheduler.refresh_headers
-        mock_datetime = mocker.patch("lib.checkin_handler.datetime")
-        mock_datetime.utcnow.side_effect = [
-            datetime(1999, 12, 31, 18, 29, 59),
-            datetime(1999, 12, 31, 23, 19, 59),
-        ]
+        mocker.patch(
+            "lib.checkin_handler.get_current_time",
+            side_effect=[
+                datetime(1999, 12, 31, 18, 29, 59),
+                datetime(1999, 12, 31, 23, 19, 59),
+            ],
+        )
 
         self.handler._wait_for_check_in(datetime(1999, 12, 31, 23, 49, 59))
 

--- a/tests/unit/test_reservation_monitor.py
+++ b/tests/unit/test_reservation_monitor.py
@@ -29,9 +29,12 @@ def mock_lock(mocker: MockerFixture) -> None:
 )
 class TestReservationMonitor:
     @pytest.fixture(autouse=True)
-    def _set_up_monitor(self, mock_lock: mock.Mock) -> None:
+    def _set_up_monitor(self, mock_lock: mock.Mock, mocker: MockerFixture) -> None:
         # pylint: disable=attribute-defined-outside-init
         self.monitor = ReservationMonitor(ReservationConfig(), mock_lock)
+        mocker.patch(
+            "lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31)
+        )
 
     def test_start_starts_a_process(self, mocker: MockerFixture) -> None:
         mock_process_start = mocker.patch.object(multiprocessing.Process, "start")
@@ -159,8 +162,9 @@ class TestReservationMonitor:
 
     def test_smart_sleep_sleeps_for_correct_time(self, mocker: MockerFixture) -> None:
         mock_sleep = mocker.patch("time.sleep")
-        mock_datetime = mocker.patch("lib.reservation_monitor.datetime")
-        mock_datetime.utcnow.return_value = datetime(1999, 12, 31)
+        mocker.patch(
+            "lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31)
+        )
 
         self.monitor.config.retrieval_interval = 24 * 60 * 60
         self.monitor._smart_sleep(datetime(1999, 12, 30, 12))
@@ -187,9 +191,12 @@ class TestReservationMonitor:
 )
 class TestAccountMonitor:
     @pytest.fixture(autouse=True)
-    def _set_up_monitor(self, mock_lock: mock.Mock) -> None:
+    def _set_up_monitor(self, mock_lock: mock.Mock, mocker: MockerFixture) -> None:
         # pylint: disable=attribute-defined-outside-init
         self.monitor = AccountMonitor(AccountConfig(), mock_lock)
+        mocker.patch(
+            "lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31)
+        )
 
     def test_monitor_monitors_the_account_continuously(self, mocker: MockerFixture) -> None:
         # Since the monitor function runs in an infinite loop, throw an Exception

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,9 @@
 import json
+import socket
+from datetime import datetime
 from typing import Any
 
+import ntplib
 import pytest
 from pytest_mock import MockerFixture
 from requests_mock.mocker import Mocker as RequestMocker
@@ -73,6 +76,22 @@ def test_make_request_handles_malformed_URLs(requests_mock: RequestMocker) -> No
     mock_post = requests_mock.get(utils.BASE_URL + "test/test2", status_code=200, text="{}")
     utils.make_request("GET", "/test//test2", {}, {})
     assert mock_post.last_request.url == utils.BASE_URL + "test/test2"
+
+
+def test_get_current_time_returns_a_datetime_from_ntp_server(mocker: MockerFixture) -> None:
+    ntp_stats = ntplib.NTPStats()
+    ntp_stats.tx_timestamp = 3155673599
+    mocker.patch("ntplib.NTPClient.request", return_value=ntp_stats)
+
+    assert utils.get_current_time() == datetime(1999, 12, 31, 23, 59, 59)
+
+
+def test_get_current_time_returns_local_datetime_on_failed_request(mocker: MockerFixture) -> None:
+    mocker.patch("ntplib.NTPClient.request", side_effect=socket.gaierror)
+    mock_datetime = mocker.patch("lib.utils.datetime")
+    mock_datetime.utcnow.return_value = datetime(1999, 12, 31, 18, 59, 59)
+
+    assert utils.get_current_time() == datetime(1999, 12, 31, 18, 59, 59)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #235. Instead of relying on the computer's local time (which may be off), the time is fetched from an NTP server when possible. This ensures the script performs check-ins at the correct times even when the local time is incorrect.