### PR TITLE
Add a timeout when waiting for headers and logins to go through and a new notice notification level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,8 @@ If there is no "Upgrading" header for that version, no post-upgrade actions need
 
 ## Upcoming
 ### New Features
-- Two new [notification levels](CONFIGURATION.md#notification-level) were added
-    - A separate notification level for successful check-in messages was added which only includes successful check-ins
-    and error messages ([#280](https://github.com/jdholtz/auto-southwest-check-in/issues/280))
-    - A notification level for notices (non-critical warnings) was added, which includes driver timeouts and Too Many Requests
-    errors during logins. This is the lowest notification level offered
+- A new [notification level](CONFIGURATION.md#notification-level) for notices (non-critical warnings) was added, which includes
+driver timeouts and Too Many Requests errors during logins. This is the lowest notification level offered
     - The default configuration is still the same. Refer to the [notification level configuration](CONFIGURATION.md#notification-level)
     for more details on the levels
     - If you have manually set `notification_level` in your config.json, see the "Upgrading" header for how to adjust it for the
@@ -23,7 +20,7 @@ checking many accounts and reservations at once
 
 ### Upgrading
 - If you manually set `notification_level` in your configuration, it will need to be adjusted accordingly.
-    - If it was set to `2` (error messages only), it needs to be set to `4`
+    - If it was set to `2` (error messages only), it needs to be set to `3`
     - If it was set to `1` (all messages), it needs to be set to `2`
     - Refer to the [notification level configuration](CONFIGURATION.md#notification-level) for more details on the levels
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,28 @@ If there is no "Upgrading" header for that version, no post-upgrade actions need
 
 
 ## Upcoming
+### New Features
+- Two new [notification levels](CONFIGURATION.md#notification-level) were added
+    - A separate notification level for successful check-in messages was added which only includes successful check-ins
+    and error messages ([#280](https://github.com/jdholtz/auto-southwest-check-in/issues/280))
+    - A notification level for notices (non-critical warnings) was added, which includes driver timeouts and Too Many Requests
+    errors during logins. This is the lowest notification level offered
+    - The default configuration is still the same. Refer to the [notification level configuration](CONFIGURATION.md#notification-level)
+    for more details on the levels
+    - If you have manually set `notification_level` in your config.json, see the "Upgrading" header for how to adjust it for the
+    new notification levels
+
 ### Improvements
 - Mitigations for 403 and 429 errors were added to significantly improve Docker and server environments as well as
 checking many accounts and reservations at once
 ([#274](https://github.com/jdholtz/auto-southwest-check-in/pull/274) by [@dmytrokoren](https://github.com/dmytrokoren))
 - Fare checks now run faster due to caching a flight's reservation information from previous queries to Southwest's API
+
+### Upgrading
+- If you manually set `notification_level` in your configuration, it will need to be adjusted accordingly.
+    - If it was set to `2` (error messages only), it needs to be set to `4`
+    - If it was set to `1` (all messages), it needs to be set to `2`
+    - Refer to the [notification level configuration](CONFIGURATION.md#notification-level) for more details on the levels
 
 
 ## 7.5 (2024-06-07)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -66,7 +66,7 @@ If you have more than one service you want to send notifications to, you can put
 ```
 
 ### Notification Level
-Default: 1 \
+Default: 2 \
 Type: Integer \
 Environment Variable: `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_LEVEL`
 > Using the environment variable will override the applicable setting in `config.json`.
@@ -74,12 +74,14 @@ Environment Variable: `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_LEVEL`
 You can also select the level of notifications you want to receive.
 ```json
 {
-  "notification_level": 1
+  "notification_level": 2
 }
 ```
-`Level 1`: Receive successful scheduling messages, lower fare messages, and all messages in later levels.\
-`Level 2`: Receive successful check-in messages and all messages in later levels.\
-`Level 3`: Receive only error messages (failed scheduling and check-ins).
+`Level 1`: Receive notices of skipped reservation retrievals due to driver timeouts and Too Many Requests errors
+during logins as well as all messages in later levels.\
+`Level 2`: Receive successful scheduling messages, lower fare messages, and all messages in later levels.\
+`Level 3`: Receive successful check-in messages and all messages in later levels.\
+`Level 4`: Receive only error messages (failed scheduling and check-ins).
 
 ### Notification 24 Hour Time
 Default: false \

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -79,9 +79,8 @@ You can also select the level of notifications you want to receive.
 ```
 `Level 1`: Receive notices of skipped reservation retrievals due to driver timeouts and Too Many Requests errors
 during logins as well as all messages in later levels.\
-`Level 2`: Receive successful scheduling messages, lower fare messages, and all messages in later levels.\
-`Level 3`: Receive successful check-in messages and all messages in later levels.\
-`Level 4`: Receive only error messages (failed scheduling and check-ins).
+`Level 2`: Receive successful scheduling and check-in messages, lower fare messages, and all messages in later levels.\
+`Level 3`: Receive only error messages (failed scheduling and check-ins).
 
 ### Notification 24 Hour Time
 Default: false \

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -77,8 +77,9 @@ You can also select the level of notifications you want to receive.
   "notification_level": 1
 }
 ```
-Level 1 means you receive successful scheduling and check-in messages, lower fare messages, and all messages in later levels.\
-Level 2 means you receive only error messages (failed scheduling and check-ins).
+`Level 1`: Receive successful scheduling messages, lower fare messages, and all messages in later levels.\
+`Level 2`: Receive successful check-in messages and all messages in later levels.\
+`Level 3`: Receive only error messages (failed scheduling and check-ins).
 
 ### Notification 24 Hour Time
 Default: false \

--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -103,9 +103,8 @@ class CheckInHandler:
                 try:
                     self.checkin_scheduler.refresh_headers()
                 except DriverTimeoutError:
-                    logger.warning(
-                        "Timeout while refreshing headers before check-in. Flight check-in may fail"
-                    )
+                    logger.debug("Timeout while refreshing headers before check-in")
+                    self.notification_handler.timeout_before_checkin(self.flight)
 
             logger.debug("Lock released")
             current_time = get_current_time()

--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict
 
 from .flight import Flight
 from .log import get_logger
-from .utils import RequestError, get_current_time, make_request
+from .utils import DriverTimeoutError, RequestError, get_current_time, make_request
 
 if TYPE_CHECKING:
     from .checkin_scheduler import CheckInScheduler
@@ -100,7 +100,12 @@ class CheckInHandler:
             logger.debug("Acquiring lock...")
             with self.lock:
                 logger.debug("Lock acquired")
-                self.checkin_scheduler.refresh_headers()
+                try:
+                    self.checkin_scheduler.refresh_headers()
+                except DriverTimeoutError:
+                    logger.warning(
+                        "Timeout while refreshing headers before check-in. Flight check-in may fail"
+                    )
 
             logger.debug("Lock released")
             current_time = get_current_time()

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -73,7 +73,7 @@ class NotificationHandler:
 
     def failed_reservation_retrieval(self, error: RequestError, confirmation_number: str) -> None:
         error_message = (
-            f"Failed to retrieve reservation for {self._get_account_name()} "
+            f"Error: Failed to retrieve reservation for {self._get_account_name()} "
             f"with confirmation number {confirmation_number}. Reason: {error}.\n"
             "Make sure the reservation information is correct and try again.\n"
         )
@@ -96,8 +96,8 @@ class NotificationHandler:
 
     def failed_login(self, error: LoginError) -> None:
         error_message = (
-            f"Failed to log in to account with username {self.reservation_monitor.username}. "
-            f"{error}.\n"
+            "Error: Failed to log in to account with username "
+            f"{self.reservation_monitor.username}. {error}.\n"
         )
         logger.debug("Sending failed login notification...")
         self.send_notification(error_message, NotificationLevel.ERROR)
@@ -121,7 +121,7 @@ class NotificationHandler:
 
     def failed_checkin(self, error: RequestError, flight: Flight) -> None:
         error_message = (
-            f"Failed to check in to flight {flight.confirmation_number} for "
+            f"Error: Failed to check in to flight {flight.confirmation_number} for "
             f"{self._get_account_name()}. Reason: {error}.\nCheck in at this url: "
             f"{MANUAL_CHECKIN_URL}\n"
         )
@@ -133,7 +133,7 @@ class NotificationHandler:
         flight_time = flight.get_display_time(twenty_four_hr_time)
 
         error_message = (
-            "Timed out waiting for headers before check-in. Check-in to flight "
+            "Error: Timed out waiting for headers before check-in. Check-in to flight "
             f"{flight.confirmation_number} for {self._get_account_name()} at {flight_time} may "
             "fail.\n"
         )

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -80,6 +80,20 @@ class NotificationHandler:
         logger.debug("Sending failed reservation retrieval notification...")
         self.send_notification(error_message, NotificationLevel.ERROR)
 
+    def timeout_during_retrieval(self, monitor_type: str) -> None:
+        message = (
+            f"Notice: Webdriver time out during {monitor_type} retrieval for "
+            f"{self._get_account_name()}. Skipping reservation retrieval until next interval\n"
+        )
+        self.send_notification(message, NotificationLevel.NOTICE)
+
+    def too_many_requests_during_login(self) -> None:
+        message = (
+            "Notice: Encountered a Too Many Requests error while logging in for "
+            f"{self._get_account_name()}. Skipping reservation retrieval until next interval\n"
+        )
+        self.send_notification(message, NotificationLevel.NOTICE)
+
     def failed_login(self, error: LoginError) -> None:
         error_message = (
             f"Failed to log in to account with username {self.reservation_monitor.username}. "
@@ -114,6 +128,18 @@ class NotificationHandler:
         logger.debug("Sending failed check-in notification...")
         self.send_notification(error_message, NotificationLevel.ERROR)
 
+    def timeout_before_checkin(self, flight: Flight) -> None:
+        twenty_four_hr_time = self.reservation_monitor.config.notification_24_hour_time
+        flight_time = flight.get_display_time(twenty_four_hr_time)
+
+        error_message = (
+            "Timed out waiting for headers before check-in. Check-in to flight "
+            f"{flight.confirmation_number} for {self._get_account_name()} at {flight_time} may "
+            "fail.\n"
+        )
+        logger.debug("Sending timeout before check-in notification...")
+        self.send_notification(error_message, NotificationLevel.ERROR)
+
     def lower_fare(self, flight: Flight, price_info: str) -> None:
         twenty_four_hr_time = self.reservation_monitor.config.notification_24_hour_time
         flight_time = flight.get_display_time(twenty_four_hr_time)
@@ -136,4 +162,13 @@ class NotificationHandler:
             requests.post(self.reservation_monitor.config.healthchecks_url + "/fail", data=data)
 
     def _get_account_name(self) -> str:
+        # hasattr has to be used instead of isinstance to avoid a circular import
+        if (
+            hasattr(self.reservation_monitor, "username")
+            and not self.reservation_monitor.first_name
+        ):
+            # No name has been set, so use the account's username. A ReservationMonitor will always
+            # have a name set, but check if it is an AccountMonitor (through hasattr) just in case
+            return self.reservation_monitor.username
+
         return f"{self.reservation_monitor.first_name} {self.reservation_monitor.last_name}"

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -117,7 +117,7 @@ class NotificationHandler:
                     )
 
         logger.debug("Sending successful check-in notification...")
-        self.send_notification(success_message, NotificationLevel.CHECKIN)
+        self.send_notification(success_message, NotificationLevel.INFO)
 
     def failed_checkin(self, error: RequestError, flight: Flight) -> None:
         error_message = (

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -103,7 +103,7 @@ class NotificationHandler:
                     )
 
         logger.debug("Sending successful check-in notification...")
-        self.send_notification(success_message, NotificationLevel.INFO)
+        self.send_notification(success_message, NotificationLevel.CHECKIN)
 
     def failed_checkin(self, error: RequestError, flight: Flight) -> None:
         error_message = (

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -9,7 +9,7 @@ from .config import AccountConfig, ReservationConfig
 from .fare_checker import FareChecker
 from .log import get_logger
 from .notification_handler import NotificationHandler
-from .utils import FlightChangeError, LoginError, RequestError, get_current_time
+from .utils import DriverTimeoutError, FlightChangeError, LoginError, RequestError, get_current_time
 from .webdriver import WebDriver
 
 TOO_MANY_REQUESTS_CODE = 429
@@ -50,37 +50,50 @@ class ReservationMonitor:
                 self._stop_monitoring()
 
     def _monitor(self) -> None:
-        """
-        Check for reservation changes and lower fares every X hours (retrieval interval).
-        Will exit when no more flights are scheduled for check-in.
-        """
-        reservation = {"confirmationNumber": self.config.confirmation_number}
-
+        """Continuously performs checks every X hours (the retrieval interval)"""
         while True:
             time_before = get_current_time()
 
+            # Acquire a lock to prevent concurrency issues with the webdriver
             logger.debug("Acquiring lock...")
             with self.lock:
                 logger.debug("Lock acquired")
 
-                # Ensure there are valid headers
-                self.checkin_scheduler.refresh_headers()
-
-                # Schedule the reservations every time in case a flight is changed or cancelled
-                self._schedule_reservations([reservation])
-
-                if len(self.checkin_scheduler.flights) <= 0:
-                    logger.debug("No more flights are scheduled for check-in. Exiting...")
+                should_exit = self._perform_check()
+                if should_exit:
+                    logger.debug("Stopping monitoring")
                     break
 
-                self._check_flight_fares()
-
                 if self.config.retrieval_interval <= 0:
-                    logger.debug("Reservation monitoring is disabled as retrieval interval is 0")
+                    logger.debug("Monitoring is disabled as retrieval interval is 0")
                     break
 
             logger.debug("Lock released")
             self._smart_sleep(time_before)
+
+    def _perform_check(self) -> bool:
+        """
+        Check for reservation changes and lower fares. Returns true if future checks should not be
+        performed (e.g. no more flights are scheduled to check in).
+        """
+        reservation = {"confirmationNumber": self.config.confirmation_number}
+
+        # Ensure there are valid headers
+        try:
+            self.checkin_scheduler.refresh_headers()
+        except DriverTimeoutError:
+            logger.warning("Timeout while refreshing headers. Skipping reservation retrieval")
+            return False
+
+        # Schedule the reservations every time in case a flight is changed or cancelled
+        self._schedule_reservations([reservation])
+
+        if len(self.checkin_scheduler.flights) <= 0:
+            logger.debug("No more flights are scheduled for check-in. Exiting...")
+            return True
+
+        self._check_flight_fares()
+        return False
 
     def _schedule_reservations(self, reservations: List[Dict[str, Any]]) -> None:
         logger.debug("Scheduling flight check-ins for %d reservations", len(reservations))
@@ -158,35 +171,27 @@ class AccountMonitor(ReservationMonitor):
         self.username = config.username
         self.password = config.password
 
-    def _monitor(self) -> None:
+    def _perform_check(self) -> bool:
         """
-        Check for newly booked reservations for the account every X hours (retrieval interval).
+        Check for newly booked reservations for the account. Returns true if future checks should
+        not be performed.
         """
-        while True:
-            time_before = get_current_time()
+        reservations, skip_scheduling = self._get_reservations()
 
-            logger.debug("Acquiring lock...")
-            with self.lock:
-                logger.debug("Lock acquired")
-                reservations, skip_scheduling = self._get_reservations()
+        if not skip_scheduling:
+            self._schedule_reservations(reservations)
+            self._check_flight_fares()
 
-                if not skip_scheduling:
-                    self._schedule_reservations(reservations)
-                    self._check_flight_fares()
-
-                if self.config.retrieval_interval <= 0:
-                    logger.debug("Account monitoring is disabled as retrieval interval is 0")
-                    break
-
-            logger.debug("Lock released")
-            self._smart_sleep(time_before)
+        # There are currently no scenarios where future checks should not be performed within
+        # this scope
+        return False
 
     def _get_reservations(self) -> Tuple[List[Dict[str, Any]], bool]:
         """
         Returns a list of reservations and a boolean indicating if reservation
         scheduling should be skipped.
 
-        Reservation scheduling will be skipped if a Too Many Requests error is encountered
+        Reservation scheduling will be skipped if a Too Many Requests error or timeout occurs
         because new headers might not be valid and a list of reservations could not be retrieved.
         """
         logger.debug("Retrieving reservations for account")
@@ -194,6 +199,11 @@ class AccountMonitor(ReservationMonitor):
 
         try:
             reservations = webdriver.get_reservations(self)
+        except DriverTimeoutError:
+            logger.warning(
+                "Timeout while retrieving reservations during login. Skipping reservation retrieval"
+            )
+            return [], True
         except LoginError as err:
             if err.status_code == TOO_MANY_REQUESTS_CODE:
                 # Don't exit when a Too Many Requests error happens. Instead, just skip the

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -128,8 +128,7 @@ class DriverTimeoutError(Exception):
 class NotificationLevel(IntEnum):
     NOTICE = 1
     INFO = 2
-    CHECKIN = 3
-    ERROR = 4
+    ERROR = 3
 
 
 def is_truthy(arg: Union[bool, int, str]) -> bool:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -126,9 +126,10 @@ class DriverTimeoutError(Exception):
 
 
 class NotificationLevel(IntEnum):
-    INFO = 1
-    CHECKIN = 2
-    ERROR = 3
+    NOTICE = 1
+    INFO = 2
+    CHECKIN = 3
+    ERROR = 4
 
 
 def is_truthy(arg: Union[bool, int, str]) -> bool:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -109,16 +109,20 @@ class RequestError(Exception):
         self.southwest_code = response_json.get("code")
 
 
-# Make a custom exception when a login fails
 class LoginError(Exception):
+    """A custom exception when a login fails"""
+
     def __init__(self, reason: str, status_code: int) -> None:
         super().__init__(f"Reason: {reason}. Status code: {status_code}")
         self.status_code = status_code
 
 
-# Make a custom exception for flights that cannot be changed
 class FlightChangeError(Exception):
-    pass
+    """A custom exception for flights that cannot be changed"""
+
+
+class DriverTimeoutError(Exception):
+    """A custom exception for when the webdriver times out waiting for attributes to be set"""
 
 
 class NotificationLevel(IntEnum):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -127,7 +127,8 @@ class DriverTimeoutError(Exception):
 
 class NotificationLevel(IntEnum):
     INFO = 1
-    ERROR = 2
+    CHECKIN = 2
+    ERROR = 3
 
 
 def is_truthy(arg: Union[bool, int, str]) -> bool:

--- a/tests/unit/test_checkin_handler.py
+++ b/tests/unit/test_checkin_handler.py
@@ -132,6 +132,9 @@ class TestCheckInHandler:
         mocker.patch.object(
             self.handler.checkin_scheduler, "refresh_headers", side_effect=DriverTimeoutError
         )
+        mock_timeout_before_checkin_notification = mocker.patch.object(
+            self.handler.notification_handler, "timeout_before_checkin"
+        )
         mocker.patch(
             "lib.checkin_handler.get_current_time",
             side_effect=[
@@ -142,6 +145,7 @@ class TestCheckInHandler:
 
         self.handler._wait_for_check_in(datetime(1999, 12, 31, 23, 49, 59))
         mock_sleep.assert_has_calls([mock.call(17400), mock.call(1800)])
+        mock_timeout_before_checkin_notification.assert_called_once()
 
     @pytest.mark.parametrize(["weeks", "expected_sleep_calls"], [(0, 0), (1, 1), (3, 2)])
     def test_safe_sleep_sleeps_in_intervals(
@@ -169,13 +173,14 @@ class TestCheckInHandler:
         self, mocker: MockerFixture
     ) -> None:
         post_response = {"checkInConfirmationPage": "Checked In!"}
-        mock_notification_handler = mocker.patch("lib.notification_handler.NotificationHandler")
+        mock_successful_checkin_notification = mocker.patch.object(
+            self.handler.notification_handler, "successful_checkin"
+        )
         mocker.patch.object(CheckInHandler, "_attempt_check_in", return_value=post_response)
 
-        self.handler.notification_handler = mock_notification_handler
         self.handler._check_in()
 
-        mock_notification_handler.successful_checkin.assert_called_once_with(
+        mock_successful_checkin_notification.assert_called_once_with(
             "Checked In!", self.handler.flight
         )
 

--- a/tests/unit/test_checkin_handler.py
+++ b/tests/unit/test_checkin_handler.py
@@ -6,7 +6,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from lib.checkin_handler import MAX_CHECK_IN_ATTEMPTS, CheckInHandler
-from lib.utils import RequestError
+from lib.utils import DriverTimeoutError, RequestError
 
 # This needs to be accessed to be tested
 # pylint: disable=protected-access
@@ -85,7 +85,7 @@ class TestCheckInHandler:
         self.handler._wait_for_check_in(datetime(1999, 12, 31, 18))
         mock_sleep.assert_not_called()
 
-    def test_wait_for_check_in_sleeps_once_when_check_in_is_less_than_thirty_minutes_away(
+    def test_wait_for_check_in_sleeps_once_when_check_in_is_less_than_or_equal_to_thirty_mins_away(
         self, mocker: MockerFixture
     ) -> None:
         mock_sleep = mocker.patch("time.sleep")
@@ -105,7 +105,9 @@ class TestCheckInHandler:
         self, mocker: MockerFixture
     ) -> None:
         mock_sleep = mocker.patch("time.sleep")
-        mock_refresh_headers = self.handler.checkin_scheduler.refresh_headers
+        mock_refresh_headers = mocker.patch.object(
+            self.handler.checkin_scheduler, "refresh_headers"
+        )
         mocker.patch(
             "lib.checkin_handler.get_current_time",
             side_effect=[
@@ -118,6 +120,28 @@ class TestCheckInHandler:
 
         mock_sleep.assert_has_calls([mock.call(17400), mock.call(1800)])
         mock_refresh_headers.assert_called_once()
+
+    @pytest.mark.filterwarnings(
+        # Mocking multiprocessing.Lock causes this warning
+        "ignore:Mocks returned by pytest-mock do not need to be used as context managers:"
+    )
+    def test_wait_for_check_in_handles_timeout_refreshing_headers(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_sleep = mocker.patch("time.sleep")
+        mocker.patch.object(
+            self.handler.checkin_scheduler, "refresh_headers", side_effect=DriverTimeoutError
+        )
+        mocker.patch(
+            "lib.checkin_handler.get_current_time",
+            side_effect=[
+                datetime(1999, 12, 31, 18, 29, 59),
+                datetime(1999, 12, 31, 23, 19, 59),
+            ],
+        )
+
+        self.handler._wait_for_check_in(datetime(1999, 12, 31, 23, 49, 59))
+        mock_sleep.assert_has_calls([mock.call(17400), mock.call(1800)])
 
     @pytest.mark.parametrize(["weeks", "expected_sleep_calls"], [(0, 0), (1, 1), (3, 2)])
     def test_safe_sleep_sleeps_in_intervals(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -72,7 +72,8 @@ class TestConfig:
             {"healthchecks_url": 0},
             {"notification_24_hour_time": "invalid"},
             {"notification_level": "invalid"},
-            {"notification_level": 4},
+            {"notification_level": -1},
+            {"notification_level": 5},
             {"notification_urls": None},
             {"retrieval_interval": "invalid"},
         ],
@@ -90,7 +91,7 @@ class TestConfig:
                 "check_fares": False,
                 "healthchecks_url": "test_healthchecks",
                 "notification_24_hour_time": False,
-                "notification_level": 2,
+                "notification_level": 3,
                 "notification_urls": "test_url",
                 "retrieval_interval": 30,
             }

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -73,7 +73,7 @@ class TestConfig:
             {"notification_24_hour_time": "invalid"},
             {"notification_level": "invalid"},
             {"notification_level": -1},
-            {"notification_level": 5},
+            {"notification_level": 4},
             {"notification_urls": None},
             {"retrieval_interval": "invalid"},
         ],
@@ -100,7 +100,7 @@ class TestConfig:
         assert test_config.check_fares is False
         assert test_config.healthchecks_url == "test_healthchecks"
         assert test_config.notification_24_hour_time is False
-        assert test_config.notification_level == NotificationLevel.CHECKIN
+        assert test_config.notification_level == NotificationLevel.ERROR
         assert test_config.notification_urls == ["test_url"]
         assert test_config.retrieval_interval == 30 * 60 * 60
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -48,7 +48,7 @@ class TestConfig:
                 "check_fares": False,
                 "healthchecks_url": "test_healthchecks",
                 "notification_24_hour_time": False,
-                "notification_level": 2,
+                "notification_level": 3,
                 "notification_urls": ["url2"],
                 "retrieval_interval": 10,
             }
@@ -72,7 +72,7 @@ class TestConfig:
             {"healthchecks_url": 0},
             {"notification_24_hour_time": "invalid"},
             {"notification_level": "invalid"},
-            {"notification_level": 3},
+            {"notification_level": 4},
             {"notification_urls": None},
             {"retrieval_interval": "invalid"},
         ],
@@ -99,7 +99,7 @@ class TestConfig:
         assert test_config.check_fares is False
         assert test_config.healthchecks_url == "test_healthchecks"
         assert test_config.notification_24_hour_time is False
-        assert test_config.notification_level == NotificationLevel.ERROR
+        assert test_config.notification_level == NotificationLevel.CHECKIN
         assert test_config.notification_urls == ["test_url"]
         assert test_config.retrieval_interval == 30 * 60 * 60
 

--- a/tests/unit/test_notification_handler.py
+++ b/tests/unit/test_notification_handler.py
@@ -105,7 +105,7 @@ class TestNotificationHandler:
             },
             mock_flight,
         )
-        assert mock_send_notification.call_args[0][1] == NotificationLevel.CHECKIN
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.INFO
 
     def test_successful_checkin_does_not_include_notification_for_lap_child(
         self, mocker: MockerFixture
@@ -131,7 +131,7 @@ class TestNotificationHandler:
         )
         assert "John got A1!" in mock_send_notification.call_args[0][0]
         assert "Lap Child" not in mock_send_notification.call_args[0][0]
-        assert mock_send_notification.call_args[0][1] == NotificationLevel.CHECKIN
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.INFO
 
     def test_failed_checkin_sends_error_notification(self, mocker: MockerFixture) -> None:
         mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")

--- a/tests/unit/test_notification_handler.py
+++ b/tests/unit/test_notification_handler.py
@@ -73,6 +73,20 @@ class TestNotificationHandler:
         self.handler.failed_login("")
         assert mock_send_notification.call_args[0][1] == NotificationLevel.ERROR
 
+    def test_timeout_during_retrieval_sends_notice_notification(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
+        self.handler.timeout_during_retrieval("test")
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.NOTICE
+
+    def test_too_many_requests_during_login_sends_notice_notification(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
+        self.handler.too_many_requests_during_login()
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.NOTICE
+
     def test_successful_checkin_sends_notification_for_check_in(
         self, mocker: MockerFixture
     ) -> None:
@@ -126,6 +140,13 @@ class TestNotificationHandler:
         self.handler.failed_checkin("", mock_flight)
         assert mock_send_notification.call_args[0][1] == NotificationLevel.ERROR
 
+    def test_timeout_before_checkin_sends_error_notification(self, mocker: MockerFixture) -> None:
+        mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
+        mock_flight = mocker.patch("lib.notification_handler.Flight")
+
+        self.handler.timeout_before_checkin(mock_flight)
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.ERROR
+
     def test_lower_fare_sends_lower_fare_notification(self, mocker: MockerFixture) -> None:
         mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
         mock_flight = mocker.patch("lib.notification_handler.Flight")
@@ -153,7 +174,16 @@ class TestNotificationHandler:
         self.handler.healthchecks_fail("healthchecks fail")
         assert mock_post.call_count == expected_calls
 
-    def test_get_account_name_returns_the_correct_name(self) -> None:
+    def test_get_account_name_returns_username_when_no_name_is_set(
+        self, mocker: MockerFixture
+    ) -> None:
+        self.handler.reservation_monitor = mocker.patch("lib.reservation_monitor.AccountMonitor")
+        self.handler.reservation_monitor.first_name = None
+        self.handler.reservation_monitor.last_name = None
+        self.handler.reservation_monitor.username = "Test user"
+        assert self.handler._get_account_name() == self.handler.reservation_monitor.username
+
+    def test_get_account_name_returns_the_correct_name_when_set(self) -> None:
         self.handler.reservation_monitor.first_name = "John"
         self.handler.reservation_monitor.last_name = "Doe"
         assert self.handler._get_account_name() == "John Doe"

--- a/tests/unit/test_notification_handler.py
+++ b/tests/unit/test_notification_handler.py
@@ -91,9 +91,11 @@ class TestNotificationHandler:
             },
             mock_flight,
         )
-        assert mock_send_notification.call_args[0][1] == NotificationLevel.INFO
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.CHECKIN
 
-    def test_does_not_include_notification_for_lap_child(self, mocker: MockerFixture) -> None:
+    def test_successful_checkin_does_not_include_notification_for_lap_child(
+        self, mocker: MockerFixture
+    ) -> None:
         """
         A lap child does not get a boarding position, and does not need a notification
         """
@@ -114,8 +116,8 @@ class TestNotificationHandler:
             mock_flight,
         )
         assert "John got A1!" in mock_send_notification.call_args[0][0]
-        assert "Lap Child got NoneNone!" not in mock_send_notification.call_args[0][0]
-        assert mock_send_notification.call_args[0][1] == NotificationLevel.INFO
+        assert "Lap Child" not in mock_send_notification.call_args[0][0]
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.CHECKIN
 
     def test_failed_checkin_sends_error_notification(self, mocker: MockerFixture) -> None:
         mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")

--- a/tests/unit/test_reservation_monitor.py
+++ b/tests/unit/test_reservation_monitor.py
@@ -11,7 +11,7 @@ from lib.config import AccountConfig, ReservationConfig
 from lib.fare_checker import FareChecker
 from lib.notification_handler import NotificationHandler
 from lib.reservation_monitor import TOO_MANY_REQUESTS_CODE, AccountMonitor, ReservationMonitor
-from lib.utils import FlightChangeError, LoginError, RequestError
+from lib.utils import DriverTimeoutError, FlightChangeError, LoginError, RequestError
 from lib.webdriver import WebDriver
 
 # This needs to be accessed to be tested
@@ -55,10 +55,44 @@ class TestReservationMonitor:
         self.monitor.monitor()
         mock_stop_monitoring.assert_called_once()
 
-    def test_monitor_monitors_reservations_continuously(self, mocker: MockerFixture) -> None:
+    def test_monitor_monitors_continuously(self, mocker: MockerFixture) -> None:
         # Since the monitor function runs in an infinite loop, throw an Exception when the
         # sleep function is called a second time to break out of the loop.
         mocker.patch.object(ReservationMonitor, "_smart_sleep", side_effect=["", StopIteration])
+        mock_perform_check = mocker.patch.object(
+            ReservationMonitor, "_perform_check", return_value=False
+        )
+
+        self.monitor.config.retrieval_interval = 1
+        with pytest.raises(StopIteration):
+            self.monitor._monitor()
+
+        assert mock_perform_check.call_count == 2
+
+    def test_monitor_monitors_until_perform_check_says_to_exit(self, mocker: MockerFixture) -> None:
+        mock_smart_sleep = mocker.patch.object(ReservationMonitor, "_smart_sleep")
+        mocker.patch.object(ReservationMonitor, "_perform_check", side_effect=[False, False, True])
+
+        self.monitor.config.retrieval_interval = 1
+        self.monitor._monitor()
+
+        assert mock_smart_sleep.call_count == 2
+
+    def test_monitor_monitors_once_if_retrieval_interval_is_zero(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_smart_sleep = mocker.patch.object(ReservationMonitor, "_smart_sleep")
+        mock_perform_check = mocker.patch.object(
+            ReservationMonitor, "_perform_check", return_value=False
+        )
+
+        self.monitor.config.retrieval_interval = 0
+        self.monitor._monitor()
+
+        mock_perform_check.assert_called_once()
+        mock_smart_sleep.assert_not_called()
+
+    def test_perform_check_checks_reservations(self, mocker: MockerFixture) -> None:
         mock_refresh_headers = mocker.patch.object(CheckInScheduler, "refresh_headers")
         mock_schedule_reservations = mocker.patch.object(
             ReservationMonitor, "_schedule_reservations"
@@ -68,52 +102,45 @@ class TestReservationMonitor:
         self.monitor.config.confirmation_number = "test_num"
         self.monitor.checkin_scheduler.flights = ["test_flight"]
 
-        with pytest.raises(StopIteration):
-            self.monitor._monitor()
+        should_exit = self.monitor._perform_check()
 
-        assert mock_refresh_headers.call_count == 2
-        assert mock_schedule_reservations.call_count == 2
-        mock_schedule_reservations.assert_called_with(
+        assert not should_exit
+        mock_refresh_headers.assert_called_once()
+        mock_schedule_reservations.assert_called_once_with(
             [{"confirmationNumber": self.monitor.config.confirmation_number}]
         )
-        assert mock_check_flight_fares.call_count == 2
+        mock_check_flight_fares.assert_called_once()
 
-    def test_monitor_stops_monitoring_when_no_flights_are_scheduled(
-        self, mocker: MockerFixture
-    ) -> None:
-        mock_smart_sleep = mocker.patch.object(ReservationMonitor, "_smart_sleep")
-        mock_refresh_headers = mocker.patch.object(CheckInScheduler, "refresh_headers")
+    def test_perform_check_skips_scheduling_on_driver_timeout(self, mocker: MockerFixture) -> None:
+        mock_refresh_headers = mocker.patch.object(
+            CheckInScheduler, "refresh_headers", side_effect=DriverTimeoutError
+        )
         mock_schedule_reservations = mocker.patch.object(
             ReservationMonitor, "_schedule_reservations"
         )
         mock_check_flight_fares = mocker.patch.object(ReservationMonitor, "_check_flight_fares")
 
-        self.monitor._monitor()
-
-        mock_refresh_headers.assert_called_once()
-        mock_schedule_reservations.assert_called_once()
-        mock_check_flight_fares.assert_not_called()
-        mock_smart_sleep.assert_not_called()
-
-    def test_monitor_monitors_reservations_once_if_retrieval_interval_is_zero(
-        self, mocker: MockerFixture
-    ) -> None:
-        mock_smart_sleep = mocker.patch.object(ReservationMonitor, "_smart_sleep")
-        mock_refresh_headers = mocker.patch.object(CheckInScheduler, "refresh_headers")
-        mock_schedule_reservations = mocker.patch.object(
-            ReservationMonitor, "_schedule_reservations"
-        )
-        mock_check_flight_fares = mocker.patch.object(ReservationMonitor, "_check_flight_fares")
-
-        self.monitor.config.retrieval_interval = 0
+        self.monitor.config.confirmation_number = "test_num"
         self.monitor.checkin_scheduler.flights = ["test_flight"]
 
-        self.monitor._monitor()
+        should_exit = self.monitor._perform_check()
 
+        assert not should_exit
         mock_refresh_headers.assert_called_once()
-        mock_schedule_reservations.assert_called_once()
-        mock_check_flight_fares.assert_called_once()
-        mock_smart_sleep.assert_not_called()
+        mock_schedule_reservations.assert_not_called()
+        mock_check_flight_fares.assert_not_called()
+
+    def test_perform_check_returns_false_when_no_flights_are_scheduled(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(CheckInScheduler, "refresh_headers")
+        mocker.patch.object(ReservationMonitor, "_schedule_reservations")
+        mock_check_flight_fares = mocker.patch.object(ReservationMonitor, "_check_flight_fares")
+
+        should_exit = self.monitor._perform_check()
+
+        assert should_exit
+        mock_check_flight_fares.assert_not_called()
 
     def test_schedule_reservations_schedules_reservations_correctly(
         self, mocker: MockerFixture
@@ -198,60 +225,37 @@ class TestAccountMonitor:
             "lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31)
         )
 
-    def test_monitor_monitors_the_account_continuously(self, mocker: MockerFixture) -> None:
-        # Since the monitor function runs in an infinite loop, throw an Exception
-        # when the sleep function is called a second time to break out of the loop.
-        mocker.patch.object(AccountMonitor, "_smart_sleep", side_effect=["", StopIteration])
-        mock_get_reservations = mocker.patch.object(
-            AccountMonitor, "_get_reservations", return_value=([], False)
-        )
+    def test_perform_check_checks_account_for_reservations(self, mocker: MockerFixture) -> None:
+        mocker.patch.object(AccountMonitor, "_get_reservations", return_value=([], False))
         mock_schedule_reservations = mocker.patch.object(AccountMonitor, "_schedule_reservations")
         mock_check_flight_fares = mocker.patch.object(AccountMonitor, "_check_flight_fares")
 
-        with pytest.raises(StopIteration):
-            self.monitor._monitor()
+        should_exit = self.monitor._perform_check()
 
-        assert mock_get_reservations.call_count == 2
-        assert mock_schedule_reservations.call_count == 2
-        assert mock_check_flight_fares.call_count == 2
-
-    def test_monitor_skips_scheduling_on_too_many_requests_error(
-        self, mocker: MockerFixture
-    ) -> None:
-        # Since the monitor function runs in an infinite loop, throw an Exception
-        # when the sleep function is called a second time to break out of the loop.
-        mocker.patch.object(AccountMonitor, "_smart_sleep", side_effect=[StopIteration])
-        mock_get_reservations = mocker.patch.object(
-            AccountMonitor, "_get_reservations", return_value=([], True)
-        )
-        mock_schedule_reservations = mocker.patch.object(AccountMonitor, "_schedule_reservations")
-        mock_check_flight_fares = mocker.patch.object(AccountMonitor, "_check_flight_fares")
-
-        with pytest.raises(StopIteration):
-            self.monitor._monitor()
-
-        assert mock_get_reservations.call_count == 1
-        assert mock_schedule_reservations.call_count == 0
-        assert mock_check_flight_fares.call_count == 0
-
-    def test_monitor_checks_reservations_once_if_retrieval_interval_is_zero(
-        self,
-        mocker: MockerFixture,
-    ) -> None:
-        mock_smart_sleep = mocker.patch.object(AccountMonitor, "_smart_sleep")
-        mock_get_reservations = mocker.patch.object(
-            AccountMonitor, "_get_reservations", return_value=([], False)
-        )
-        mock_schedule_reservations = mocker.patch.object(AccountMonitor, "_schedule_reservations")
-        mock_check_flight_fares = mocker.patch.object(AccountMonitor, "_check_flight_fares")
-
-        self.monitor.config.retrieval_interval = 0
-        self.monitor._monitor()
-
-        mock_smart_sleep.assert_not_called()
-        mock_get_reservations.assert_called_once()
+        assert not should_exit
         mock_schedule_reservations.assert_called_once()
         mock_check_flight_fares.assert_called_once()
+
+    def test_perform_check_skips_scheduling_if_an_error_occurs(self, mocker: MockerFixture) -> None:
+        # If an error occurs, _get_reservations will return an empty list of reservations and
+        # true indicating scheduling should be skipped
+        mocker.patch.object(AccountMonitor, "_get_reservations", return_value=([], True))
+        mock_schedule_reservations = mocker.patch.object(AccountMonitor, "_schedule_reservations")
+        mock_check_flight_fares = mocker.patch.object(AccountMonitor, "_check_flight_fares")
+
+        should_exit = self.monitor._perform_check()
+
+        assert not should_exit
+        mock_schedule_reservations.assert_not_called()
+        mock_check_flight_fares.assert_not_called()
+
+    def test_get_reservations_skips_retrieval_on_driver_timeout(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(WebDriver, "get_reservations", side_effect=DriverTimeoutError)
+        reservations, skip_scheduling = self.monitor._get_reservations()
+        assert len(reservations) == 0
+        assert skip_scheduling
 
     def test_get_reservations_skips_retrieval_on_too_many_requests_error(
         self, mocker: MockerFixture

--- a/tests/unit/test_webdriver.py
+++ b/tests/unit/test_webdriver.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 from pytest_mock import MockerFixture
 
-from lib.utils import LoginError
+from lib.utils import DriverTimeoutError, LoginError
 from lib.webdriver import HEADERS_URL, INVALID_CREDENTIALS_CODE, LOGIN_URL, TRIPS_URL, WebDriver
 
 # This needs to be accessed to be tested
@@ -143,6 +143,11 @@ class TestWebDriver:
         mocker.patch("time.sleep", side_effect=mock_sleep)
 
         self.driver._wait_for_attribute("headers_set")
+
+    def test_wait_for_attribute_raises_error_on_timeout(self, mocker: MockerFixture) -> None:
+        mocker.patch("time.sleep")
+        with pytest.raises(DriverTimeoutError):
+            self.driver._wait_for_attribute("headers_set")
 
     def test_wait_for_login_raises_error_on_failed_login(
         self, mocker: MockerFixture, mock_chrome: mock.Mock


### PR DESCRIPTION
Fixes #249.

Adds a new notification level:
'Notice' messages which are non-critical warnings during reservation retrieval about timeouts while waiting for logins/headers or encountering a Too Many Requests error during login. It is the lowest notification level.

Also adds functionality to timeout after 3 minutes of waiting for a login response or headers to be retrieved. This was implemented to ensure a process doesn't hang forever and cause a deadlock while using the webdriver. 