### PR TITLE
Add a same day option for the fare checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ If there is no "Upgrading" header for that version, no post-upgrade actions need
 
 
 ## Upcoming
+### New Features
+- Fare drops can now be checked for all flights on the same day or all nonstop flights on the same day
+([#303](https://github.com/jdholtz/auto-southwest-check-in/pulls/303))
+    - The following values in your `check_fares` configuration will enable this feature
+        - `same_day` will check all flights on the same day
+        - `same_day_nonstop` will check all nonstop flights on the same day
+    - Detailed information can be found in the [check_fares documentation](CONFIGURATION.md#check-fares)
+
 ### Improvements
 - Potentially speed up the check-in process
     - Check-ins now start exactly 24 hours before a flight (instead of 24 hours and 5 seconds)

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -9,7 +9,7 @@ Auto-Southwest Check-In supports both global configuration and account/reservati
 reservation-specific configurations).
 
 ## Table of Contents
-- [Fare Check](#fare-check)
+- [Check Fares](#check-fares)
 - [Notifications](#notifications)
     * [Notification URLS](#notification-urls)
     * [Notification Level](#notification-level)
@@ -22,21 +22,27 @@ reservation-specific configurations).
     * [Reservations](#reservations)
 - [Healthchecks URL](#healthchecks-url)
 
-## Fare Check
+## Check Fares
 Default: true \
-Type: Boolean \
+Type: Boolean or String \
 Environment Variable: `AUTO_SOUTHWEST_CHECK_IN_CHECK_FARES`
 > Using the environment variable will override the applicable setting in `config.json`.
 
-In addition to automatically checking in, check for price drops on an interval
+In addition to automatically checking in, flights can be automatically checked for price drops on an interval
 (see [Retrieval Interval](#retrieval-interval)). If a lower fare is found, the user will be notified.
 
 **Note**: Companion passes are not supported for fare checking.
 ```json
 {
-    "check_fares": true
+    "check_fares": "<value>"
 }
 ```
+
+### Check Fares Values
+- `false` or `"no"`: Do not check for lower fares
+- `true` or `"same_flight"`: Check for lower fares on the same flight
+- `"same_day_nonstop"`: Check for lower fares on all nonstop flights on the same day as the flight
+- `"same_day"`: Check for lower fares on all flights on the same day as the flight
 
 ## Notifications
 ### Notification URLs
@@ -179,7 +185,7 @@ and/or not provide reservation information as arguments.
 ### Account and Reservation-specific configuration
 Setting specific configuration values for an account or reservation allows you to fully customize how you want them to be
 monitored by the script. Here is a list of configuration values that can be applied to an individual account or reservation:
-- [Fare Check](#fare-check)
+- [Check Fares](#check-fares)
 - [Healthchecks URL](#healthchecks-url)
 - [Notification URLS](#notification-urls)
 - [Notification Level](#notification-level)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Auto-Southwest Check-In
 A Python script that automatically checks you in to your Southwest flight. Additionally,
 the script can notify you if the price of your flight drops before departure
-(see [Fare Check](CONFIGURATION.md#fare-check)).
+(see [Check Fares](CONFIGURATION.md#check-fares)).
 
 This script can also log in to your Southwest account and automatically schedule check-ins as
 flights are scheduled.

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -9,7 +9,14 @@ from .config import AccountConfig, ReservationConfig
 from .fare_checker import FareChecker
 from .log import get_logger
 from .notification_handler import NotificationHandler
-from .utils import DriverTimeoutError, FlightChangeError, LoginError, RequestError, get_current_time
+from .utils import (
+    CheckFaresOption,
+    DriverTimeoutError,
+    FlightChangeError,
+    LoginError,
+    RequestError,
+    get_current_time,
+)
 from .webdriver import WebDriver
 
 TOO_MANY_REQUESTS_CODE = 429
@@ -102,7 +109,7 @@ class ReservationMonitor:
         self.checkin_scheduler.process_reservations(confirmation_numbers)
 
     def _check_flight_fares(self) -> None:
-        if not self.config.check_fares:
+        if self.config.check_fares == CheckFaresOption.NO:
             return
 
         flights = self.checkin_scheduler.flights

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -3,7 +3,7 @@ import random
 import socket
 import time
 from datetime import datetime, timezone
-from enum import IntEnum, StrEnum
+from enum import Enum, IntEnum
 from typing import Any, Dict, Union
 
 import ntplib
@@ -162,7 +162,8 @@ class NotificationLevel(IntEnum):
     ERROR = 3
 
 
-class CheckFaresOption(StrEnum):
+# Switch to StrEnum when Python 3.10 support is dropped
+class CheckFaresOption(str, Enum):
     NO = "no"
     SAME_FLIGHT = "same_flight"
     SAME_DAY_NONSTOP = "same_day_nonstop"

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -3,7 +3,7 @@ import random
 import socket
 import time
 from datetime import datetime, timezone
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import Any, Dict, Union
 
 import ntplib
@@ -160,6 +160,13 @@ class NotificationLevel(IntEnum):
     NOTICE = 1
     INFO = 2
     ERROR = 3
+
+
+class CheckFaresOption(StrEnum):
+    NO = "no"
+    SAME_FLIGHT = "same_flight"
+    SAME_DAY_NONSTOP = "same_day_nonstop"
+    SAME_DAY = "same_day"
 
 
 def is_truthy(arg: Union[bool, int, str]) -> bool:

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -5,12 +5,13 @@ import json
 from pytest_mock import MockerFixture
 
 from lib.config import GlobalConfig
+from lib.utils import CheckFaresOption
 
 
 def test_config(mocker: MockerFixture) -> None:
     config = {
         "browser_path": "chrome_path",
-        "check_fares": True,
+        "check_fares": CheckFaresOption.SAME_DAY_NONSTOP,
         "notification_level": 1,
         "notification_urls": ["test1.com", "test2.com"],
         "retrieval_interval": 16,
@@ -52,7 +53,7 @@ def test_config(mocker: MockerFixture) -> None:
     account_two = config.accounts[1]
 
     assert account_one.browser_path == "chrome_path"
-    assert account_one.check_fares
+    assert account_one.check_fares == CheckFaresOption.SAME_DAY_NONSTOP
     assert account_one.notification_level == 1
     assert account_one.notification_urls == ["test1.com", "test2.com"]
     assert account_one.password == "test_pass1"
@@ -60,7 +61,7 @@ def test_config(mocker: MockerFixture) -> None:
     assert account_one.username == "test_user1"
 
     assert account_two.browser_path == "chrome_path"
-    assert not account_two.check_fares
+    assert account_two.check_fares == CheckFaresOption.NO
     assert account_two.notification_level == 2
     assert account_two.notification_urls == ["test1.com", "test2.com", "test3.com"]
     assert account_two.password == "test_pass2"
@@ -72,7 +73,7 @@ def test_config(mocker: MockerFixture) -> None:
     reservation_two = config.reservations[1]
 
     assert reservation_one.browser_path == "chrome_path"
-    assert reservation_one.check_fares
+    assert reservation_one.check_fares == CheckFaresOption.SAME_DAY_NONSTOP
     assert reservation_one.confirmation_number == "test_num1"
     assert reservation_one.first_name == "Winston"
     assert reservation_one.last_name == "Smith"
@@ -81,7 +82,7 @@ def test_config(mocker: MockerFixture) -> None:
     assert reservation_one.retrieval_interval == 16 * 3600
 
     assert reservation_two.browser_path == "chrome_path"
-    assert not reservation_two.check_fares
+    assert reservation_two.check_fares == CheckFaresOption.NO
     assert reservation_two.confirmation_number == "test_num2"
     assert reservation_two.first_name == "Edmond"
     assert reservation_two.last_name == "Dantès"

--- a/tests/unit/test_checkin_handler.py
+++ b/tests/unit/test_checkin_handler.py
@@ -21,7 +21,7 @@ class TestCheckInHandler:
         mock_checkin_scheduler = mocker.patch("lib.checkin_scheduler.CheckInScheduler")
         mock_lock = mocker.patch("multiprocessing.Lock")
 
-        # pylint: disable=attribute-defined-outside-init
+        # pylint: disable-next=attribute-defined-outside-init
         self.handler = CheckInHandler(mock_checkin_scheduler, test_flight, mock_lock)
         # This would usually be set in schedule_check_in, but that won't be run for every test
         self.handler.pid = 0

--- a/tests/unit/test_checkin_scheduler.py
+++ b/tests/unit/test_checkin_scheduler.py
@@ -36,7 +36,7 @@ def test_flights(mocker: MockerFixture) -> List[Flight]:
 class TestCheckInScheduler:
     @pytest.fixture(autouse=True)
     def _set_up_scheduler(self) -> None:
-        # pylint: disable=attribute-defined-outside-init
+        # pylint: disable-next=attribute-defined-outside-init
         self.scheduler = CheckInScheduler(ReservationMonitor(ReservationConfig()))
 
     def test_process_reservations_handles_all_reservations(self, mocker: MockerFixture) -> None:

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -28,7 +28,7 @@ class TestFlight:
         with mock.patch.object(Flight, "_set_flight_time"):
             # Reservation info can be left empty as it is only used for caching, but isn't relevant
             # to the functionality of the flight class
-            # pylint: disable=attribute-defined-outside-init
+            # pylint: disable-next=attribute-defined-outside-init
             self.flight = Flight(flight_info, {}, "test_num")
 
             # Flight times that would be set if _set_flight_time isn't mocked

--- a/tests/unit/test_notification_handler.py
+++ b/tests/unit/test_notification_handler.py
@@ -13,7 +13,7 @@ class TestNotificationHandler:
     @pytest.fixture(autouse=True)
     def notification_handler(self, mocker: MockerFixture) -> None:
         mock_reservation_monitor = mocker.patch("lib.reservation_monitor.ReservationMonitor")
-        # pylint: disable=attribute-defined-outside-init
+        # pylint: disable-next=attribute-defined-outside-init
         self.handler = NotificationHandler(mock_reservation_monitor)
 
     def test_send_nofication_does_not_send_notifications_if_level_is_too_low(

--- a/tests/unit/test_reservation_monitor.py
+++ b/tests/unit/test_reservation_monitor.py
@@ -11,7 +11,13 @@ from lib.config import AccountConfig, ReservationConfig
 from lib.fare_checker import FareChecker
 from lib.notification_handler import NotificationHandler
 from lib.reservation_monitor import TOO_MANY_REQUESTS_CODE, AccountMonitor, ReservationMonitor
-from lib.utils import DriverTimeoutError, FlightChangeError, LoginError, RequestError
+from lib.utils import (
+    CheckFaresOption,
+    DriverTimeoutError,
+    FlightChangeError,
+    LoginError,
+    RequestError,
+)
 from lib.webdriver import WebDriver
 
 # This needs to be accessed to be tested
@@ -30,7 +36,7 @@ def mock_lock(mocker: MockerFixture) -> None:
 class TestReservationMonitor:
     @pytest.fixture(autouse=True)
     def _set_up_monitor(self, mock_lock: mock.Mock, mocker: MockerFixture) -> None:
-        # pylint: disable=attribute-defined-outside-init
+        # pylint: disable-next=attribute-defined-outside-init
         self.monitor = ReservationMonitor(ReservationConfig(), mock_lock)
         mocker.patch(
             "lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31)
@@ -153,7 +159,7 @@ class TestReservationMonitor:
     ) -> None:
         mock_fare_checker = mocker.patch("lib.reservation_monitor.FareChecker")
 
-        self.monitor.config.check_fares = False
+        self.monitor.config.check_fares = CheckFaresOption.NO
         self.monitor._check_flight_fares()
 
         mock_fare_checker.assert_not_called()
@@ -162,7 +168,7 @@ class TestReservationMonitor:
         test_flight = mocker.patch("lib.checkin_handler.Flight")
         mock_check_flight_price = mocker.patch.object(FareChecker, "check_flight_price")
 
-        self.monitor.config.check_fares = True
+        self.monitor.config.check_fares = CheckFaresOption.SAME_FLIGHT
         self.monitor.checkin_scheduler.flights = [test_flight, test_flight]
         self.monitor._check_flight_fares()
 
@@ -177,7 +183,7 @@ class TestReservationMonitor:
             FareChecker, "check_flight_price", side_effect=[None, exception]
         )
 
-        self.monitor.config.check_fares = True
+        self.monitor.config.check_fares = CheckFaresOption.SAME_DAY
         self.monitor.checkin_scheduler.flights = [test_flight, test_flight]
         self.monitor._check_flight_fares()
 
@@ -215,7 +221,7 @@ class TestReservationMonitor:
 class TestAccountMonitor:
     @pytest.fixture(autouse=True)
     def _set_up_monitor(self, mock_lock: mock.Mock, mocker: MockerFixture) -> None:
-        # pylint: disable=attribute-defined-outside-init
+        # pylint: disable-next=attribute-defined-outside-init
         self.monitor = AccountMonitor(AccountConfig(), mock_lock)
         mocker.patch(
             "lib.reservation_monitor.get_current_time", return_value=datetime(1999, 12, 31)

--- a/tests/unit/test_webdriver.py
+++ b/tests/unit/test_webdriver.py
@@ -28,7 +28,7 @@ class TestWebDriver:
     def _set_up_webdriver(self, mocker: MockerFixture) -> None:
         mock_checkin_scheduler = mocker.patch("lib.checkin_scheduler.CheckInScheduler")
         mock_checkin_scheduler.headers = {}
-        # pylint: disable=attribute-defined-outside-init
+        # pylint: disable-next=attribute-defined-outside-init
         self.driver = WebDriver(mock_checkin_scheduler)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #212.

Options are documented in the Check Fares section of the configuration documentation.

Specifying the `same_day_nonstop` value to the check_fares config option will make the script will check for lower fares across all nonstop flights on the same day the flight is. Adjacently, specifying the `same_day` value for check_fares will check for lower fares across all flights on the same day, not just nonstop flights.

Integration tests were added to ensure all filters are working as expected.