### PR TITLE
Drop python 3.8 and add official support for Python 3.13 

### DIFF
--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13"
       - name: flake8
         uses: py-actions/flake8@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ information beforehand.
 ## Installation
 
 ### Prerequisites
-- [Python 3.8+]
+- [Python 3.9+]
 - [Pip]
 - [Any Chromium-based browser]
 
@@ -192,7 +192,7 @@ If you are running the script with Docker, the current workaround is to run the 
 </details>
 
 
-[Python 3.8+]: https://www.python.org/downloads/
+[Python 3.9+]: https://www.python.org/downloads/
 [Pip]: https://pip.pypa.io/en/stable/installation/
 [Any Chromium-based browser]: https://en.wikipedia.org/wiki/Chromium_(web_browser)#Active
 [Python virtual environment]: https://virtualenv.pypa.io/en/stable/

--- a/lib/checkin_handler.py
+++ b/lib/checkin_handler.py
@@ -5,7 +5,7 @@ import signal
 import time
 from datetime import datetime, timedelta
 from multiprocessing import Lock, Process
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any
 
 from .flight import Flight
 from .log import get_logger
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from .checkin_scheduler import CheckInScheduler
 
 # Type alias for JSON
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 CHECKIN_URL = "mobile-air-operations/v1/mobile-air-operations/page/check-in/"
 MANUAL_CHECKIN_URL = "https://mobile.southwest.com/check-in"
@@ -119,7 +119,7 @@ class CheckInHandler:
         logger.debug("Sleeping until check-in: %d seconds...", sleep_time)
         time.sleep(sleep_time)
 
-    def _safe_sleep(self, total_sleep_time: int) -> None:
+    def _safe_sleep(self, total_sleep_time: float) -> None:
         """
         If the total sleep time is too long, an overflow error could occur.
         Therefore, the script will continuously sleep in two week periods

--- a/lib/checkin_scheduler.py
+++ b/lib/checkin_scheduler.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 from .checkin_handler import CheckInHandler
 from .flight import Flight
@@ -32,7 +32,7 @@ class CheckInScheduler:
         self.flights = []
         self.checkin_handlers = []
 
-    def process_reservations(self, confirmation_numbers: List[str]) -> None:
+    def process_reservations(self, confirmation_numbers: list[str]) -> None:
         """
         Flights from all confirmation numbers are retrieved. Then, any new
         flights are scheduled and any flights now longer found are removed.
@@ -49,7 +49,7 @@ class CheckInScheduler:
         webdriver = WebDriver(self)
         webdriver.set_headers()
 
-    def _get_flights(self, confirmation_number: str) -> List[Flight]:
+    def _get_flights(self, confirmation_number: str) -> list[Flight]:
         """Get all flights booked on a single reservation"""
         reservation_info = self._get_reservation_info(confirmation_number)
         bounds = reservation_info.get("bounds", [])
@@ -69,7 +69,7 @@ class CheckInScheduler:
 
         return flights
 
-    def _get_reservation_info(self, confirmation_number: str) -> Dict[str, Any]:
+    def _get_reservation_info(self, confirmation_number: str) -> dict[str, Any]:
         info = {
             "firstName": self.reservation_monitor.first_name,
             "lastName": self.reservation_monitor.last_name,
@@ -94,14 +94,14 @@ class CheckInScheduler:
         logger.debug("Successfully retrieved reservation information")
         return response["viewReservationViewPage"]
 
-    def _set_same_day_flight(self, flight: Flight, previous_flights: List[Flight]) -> None:
+    def _set_same_day_flight(self, flight: Flight, previous_flights: list[Flight]) -> None:
         for prev_flight in previous_flights:
             if flight.departure_time - prev_flight.departure_time <= timedelta(hours=24):
                 logger.debug("Flight is on the same day")
                 flight.is_same_day = True
                 break
 
-    def _update_scheduled_flights(self, flights: List[Flight]) -> None:
+    def _update_scheduled_flights(self, flights: list[Flight]) -> None:
         """
         Responsible for three tasks to update scheduled flights:
           1. Schedule check-ins for any new flights
@@ -127,7 +127,7 @@ class CheckInScheduler:
 
         self._remove_old_flights(flights)
 
-    def _schedule_flights(self, flights: List[Flight]) -> None:
+    def _schedule_flights(self, flights: list[Flight]) -> None:
         logger.debug("Scheduling %d flights for check-in", len(flights))
         for flight in flights:
             checkin_handler = CheckInHandler(self, flight, self.reservation_monitor.lock)
@@ -138,7 +138,7 @@ class CheckInScheduler:
 
         self.notification_handler.new_flights(flights)
 
-    def _remove_old_flights(self, flights: List[Flight]) -> None:
+    def _remove_old_flights(self, flights: list[Flight]) -> None:
         """Remove all scheduled flights that are not in the current flight list"""
         logger.debug("%d flights are currently scheduled. Removing old flights", len(self.flights))
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -2,13 +2,13 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 from .log import get_logger
 from .utils import CheckFaresOption, NotificationLevel, is_truthy
 
 # Type alias for JSON
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 CONFIG_FILE_NAME = "config.json"
 logger = get_logger(__name__)
@@ -139,7 +139,7 @@ class GlobalConfig(Config):
         self.accounts = []
         self.reservations = []
 
-    def initialize(self) -> JSON:
+    def initialize(self) -> None:
         logger.debug("Initializing configuration file")
 
         try:
@@ -151,14 +151,14 @@ class GlobalConfig(Config):
             print(err)
             sys.exit(1)
 
-    def create_account_config(self, accounts: List[JSON]) -> None:
+    def create_account_config(self, accounts: list[JSON]) -> None:
         logger.debug("Creating configurations for %d accounts", len(accounts))
         for account_json in accounts:
             account_config = AccountConfig()
             account_config.create(account_json, self)
             self.accounts.append(account_config)
 
-    def create_reservation_config(self, reservations: List[JSON]) -> None:
+    def create_reservation_config(self, reservations: list[JSON]) -> None:
         logger.debug("Creating configurations for %d reservations", len(reservations))
         for reservation_json in reservations:
             reservation_config = ReservationConfig()

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable
 
 from .flight import Flight
 from .log import get_logger
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from .reservation_monitor import ReservationMonitor
 
 # Type alias for JSON
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 BOOKING_URL = "mobile-air-booking/"
 logger = get_logger(__name__)
@@ -49,7 +49,7 @@ class FareChecker:
         lowest_fare = self._get_lowest_fare(flight, flights, fare_type)
         return lowest_fare
 
-    def _get_matching_flights(self, flight: Flight) -> Tuple[List[JSON], str]:
+    def _get_matching_flights(self, flight: Flight) -> tuple[list[JSON], str]:
         """
         Get all of the flights that match the current flight's departure airport,
         arrival airport, and departure date.
@@ -82,7 +82,7 @@ class FareChecker:
         response = make_request("POST", site, self.headers, query, max_attempts=7)
         return response["changeShoppingPage"]["flights"][bound_page]["cards"], fare_type
 
-    def _get_change_flight_page(self, reservation_info: JSON) -> Tuple[JSON, List[JSON]]:
+    def _get_change_flight_page(self, reservation_info: JSON) -> tuple[JSON, list[JSON]]:
         fare_type_bounds = reservation_info["bounds"]
 
         # Ensure the flight does not have a companion pass connected to it
@@ -131,7 +131,7 @@ class FareChecker:
         if grey_box_message and "companion" in (grey_box_message.get("body") or ""):
             raise FlightChangeError("Fare check is not supported with companion passes")
 
-    def _get_lowest_fare(self, flight: Flight, flights: List[JSON], fare_type: str) -> JSON:
+    def _get_lowest_fare(self, flight: Flight, flights: list[JSON], fare_type: str) -> JSON:
         """
         Get the lowest fare for the queried flights based on the filter being used. If no fare is
         available for the specific fare type, a 0 USD difference will be returned.
@@ -158,7 +158,7 @@ class FareChecker:
 
         return lowest_fare
 
-    def _get_matching_fare(self, fares: List[JSON], fare_type: str) -> Optional[JSON]:
+    def _get_matching_fare(self, fares: list[JSON], fare_type: str) -> JSON | None:
         """
         Get the fare that matches the fare type. If a fare exists, the amount will be returned, as
         an integer, and the currency code (USD or points). If no fare exists, nothing will be

--- a/lib/flight.py
+++ b/lib/flight.py
@@ -4,11 +4,11 @@ import json
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytz
 
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 TZ_FILE_PATH = "utils/airport_timezones.json"
 

--- a/lib/flight.py
+++ b/lib/flight.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import zoneinfo
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-
-import pytz
 
 JSON = dict[str, Any]
 
@@ -67,14 +66,14 @@ class Flight:
         tz_file = project_dir / TZ_FILE_PATH
         airport_timezones = json.loads(tz_file.read_text())
 
-        airport_timezone = pytz.timezone(airport_timezones[airport_code])
+        airport_timezone = zoneinfo.ZoneInfo(airport_timezones[airport_code])
         return airport_timezone
 
     def _convert_to_utc(self, flight_date: str, airport_timezone: Any) -> datetime:
         flight_date = datetime.strptime(flight_date, "%Y-%m-%d %H:%M")
-        self._local_departure_time = airport_timezone.localize(flight_date)
+        self._local_departure_time = flight_date.replace(tzinfo=airport_timezone)
 
-        utc_time = self._local_departure_time.astimezone(timezone.utc).replace(tzinfo=None)
+        utc_time = self._local_departure_time.astimezone(timezone.utc)
         return utc_time
 
     def _get_flight_number(self, flights: JSON) -> str:
@@ -86,7 +85,7 @@ class Flight:
         flight_number = ""
         for flight in flights:
             # Remove the 'WN' prefix from each flight number
-            flight_number += flight["number"].replace("WN", "", 1)
+            flight_number += flight["number"].removeprefix("WN")
             # Add a slash with a zero-width space on either side
             flight_number += "\u200b/\u200b"
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import multiprocessing
 import sys
-from typing import List
 
 from lib import log
 
@@ -16,7 +15,7 @@ LOG_FILE = "logs/auto-southwest-check-in.log"
 logger = log.get_logger(__name__)
 
 
-def get_notification_urls(config: GlobalConfig) -> List[str]:
+def get_notification_urls(config: GlobalConfig) -> list[str]:
     """
     Get all notification URLS in the global config, each account, and each
     reservation. Removes duplicates so notifications are not sent twice to
@@ -63,7 +62,7 @@ def set_up_reservations(config: GlobalConfig, lock: multiprocessing.Lock) -> Non
         reservation_monitor.start()
 
 
-def set_up_check_in(arguments: List[str]) -> None:
+def set_up_check_in(arguments: list[str]) -> None:
     """
     Initialize reservation and account monitoring based on the configuration
     and arguments passed in
@@ -108,7 +107,7 @@ def set_up_check_in(arguments: List[str]) -> None:
         process.join()
 
 
-def main(arguments: List[str], version: str) -> None:
+def main(arguments: list[str], version: str) -> None:
     log.init_main_logging()
     logger.debug("Auto-Southwest Check-In %s", version)
 

--- a/lib/main.py
+++ b/lib/main.py
@@ -94,9 +94,13 @@ def set_up_check_in(arguments: list[str]) -> None:
     num_accounts = len(config.accounts)
     num_reservations = len(config.reservations)
     logger.info(
-        f"Monitoring {num_accounts} {pluralize('account', num_accounts)} and {num_reservations} "
-        f"{pluralize('reservation', num_reservations)}\n"
+        "Monitoring %s %s and %s %s\n",
+        num_accounts,
+        pluralize("account", num_accounts),
+        num_reservations,
+        pluralize("reservation", num_reservations),
     )
+
     lock = multiprocessing.Lock()
     set_up_accounts(config, lock)
     set_up_reservations(config, lock)

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Union
 
 import apprise
 import requests
@@ -10,7 +10,7 @@ from .log import get_logger
 from .utils import LoginError, NotificationLevel, RequestError
 
 if TYPE_CHECKING:
-    from .reservation_monitor import ReservationMonitor
+    from .reservation_monitor import AccountMonitor, ReservationMonitor
 
 MANUAL_CHECKIN_URL = "https://mobile.southwest.com/check-in"
 MANAGE_RESERVATION_URL_MOBILE = "https://mobile.southwest.com/view-reservation"
@@ -22,7 +22,7 @@ logger = get_logger(__name__)
 class NotificationHandler:
     """Handles all notifications that will be sent to the user either via Apprise or the console"""
 
-    def __init__(self, reservation_monitor: ReservationMonitor) -> None:
+    def __init__(self, reservation_monitor: Union[AccountMonitor, ReservationMonitor]) -> None:
         self.reservation_monitor = reservation_monitor
         self.notification_urls = reservation_monitor.config.notification_urls
         self.notification_level = reservation_monitor.config.notification_level
@@ -40,7 +40,7 @@ class NotificationHandler:
         apobj = apprise.Apprise(self.notification_urls)
         apobj.notify(title=title, body=body, body_format=apprise.NotifyFormat.TEXT)
 
-    def new_flights(self, flights: List[Flight]) -> None:
+    def new_flights(self, flights: list[Flight]) -> None:
         # Don't send notifications if no new flights are scheduled
         if len(flights) == 0:
             return
@@ -102,7 +102,7 @@ class NotificationHandler:
         logger.debug("Sending failed login notification...")
         self.send_notification(error_message, NotificationLevel.ERROR)
 
-    def successful_checkin(self, boarding_pass: Dict[str, Any], flight: Flight) -> None:
+    def successful_checkin(self, boarding_pass: dict[str, Any], flight: Flight) -> None:
         success_message = (
             f"Successfully checked in to flight from '{flight.departure_airport}' to "
             f"'{flight.destination_airport}' for {self._get_account_name()}!\n"

--- a/lib/reservation_monitor.py
+++ b/lib/reservation_monitor.py
@@ -2,7 +2,7 @@ import multiprocessing
 import sys
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Union
 
 from .checkin_scheduler import CheckInScheduler
 from .config import AccountConfig, ReservationConfig
@@ -106,7 +106,7 @@ class ReservationMonitor:
         self._check_flight_fares()
         return False
 
-    def _schedule_reservations(self, reservations: List[Dict[str, Any]]) -> None:
+    def _schedule_reservations(self, reservations: list[dict[str, Any]]) -> None:
         logger.debug("Scheduling flight check-ins for %d reservations", len(reservations))
         confirmation_numbers = [reservation["confirmationNumber"] for reservation in reservations]
         self.checkin_scheduler.process_reservations(confirmation_numbers)
@@ -197,7 +197,7 @@ class AccountMonitor(ReservationMonitor):
         # this scope
         return False
 
-    def _get_reservations(self, max_retries: int = 1) -> Tuple[List[Dict[str, Any]], bool]:
+    def _get_reservations(self, max_retries: int = 1) -> tuple[list[dict[str, Any]], bool]:
         """
         Attempts to retrieve a list of reservations and returns a tuple containing the list
         of reservations and a boolean indicating whether reservation scheduling should be skipped.

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -118,9 +118,9 @@ def get_current_time() -> datetime:
             response = c.request(NTP_BACKUP_SERVER, version=3, timeout=10)
         except (socket.gaierror, ntplib.NTPException):
             logger.debug("Error requesting time from NTP servers. Using local time")
-            return datetime.now(timezone.utc).replace(tzinfo=None)
+            return datetime.now(timezone.utc)
 
-    return datetime.fromtimestamp(response.tx_time, timezone.utc).replace(tzinfo=None)
+    return datetime.fromtimestamp(response.tx_time, timezone.utc)
 
 
 class RequestError(Exception):

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -4,7 +4,7 @@ import socket
 import time
 from datetime import datetime, timezone
 from enum import Enum, IntEnum
-from typing import Any, Dict, Union
+from typing import Any, Union
 
 import ntplib
 import requests
@@ -12,7 +12,7 @@ import requests
 from .log import get_logger
 
 # Type alias for JSON
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 BASE_URL = "https://mobile.southwest.com/api/"
 NTP_SERVER = "time.nist.gov"

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -88,8 +88,10 @@ def make_request(
             sleep_time = 0.5
 
         logger.debug(
-            f"Request error on attempt {attempts}: {error_msg}. Sleeping for {sleep_time:.2f} "
-            "seconds until next attempt"
+            "Request error on attempt %d: %s. Sleeping for %.2f seconds until next attempt",
+            attempts,
+            error_msg,
+            sleep_time,
         )
         time.sleep(sleep_time)
 

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -5,7 +5,7 @@ import os
 import re
 import sys
 import time
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any
 
 from sbvirtualdisplay import Display
 from seleniumbase import Driver
@@ -29,7 +29,7 @@ INVALID_CREDENTIALS_CODE = 400518024
 
 WAIT_TIMEOUT_SECS = 180
 
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 logger = get_logger(__name__)
 
@@ -93,7 +93,7 @@ class WebDriver:
 
         self._quit_driver(driver)
 
-    def get_reservations(self, account_monitor: AccountMonitor) -> List[JSON]:
+    def get_reservations(self, account_monitor: AccountMonitor) -> list[JSON]:
         """
         Logs into the account being monitored to retrieve a list of reservations. Since
         valid headers are produced, they are also grabbed and updated in the check-in scheduler.
@@ -236,7 +236,7 @@ class WebDriver:
             logger.debug("Login form failed to submit. Clicking login button again")
             driver.click(login_button)
 
-    def _fetch_reservations(self, driver: Driver) -> List[JSON]:
+    def _fetch_reservations(self, driver: Driver) -> list[JSON]:
         """
         Waits for the reservations request to go through and returns only reservations
         that are flights.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ apprise==1.9.0
 ntplib==0.4.0
 requests==2.32.3
 seleniumbase==4.32.6
+# Only needed for Windows systems, as they don't have an IANA database by default
+tzdata>=2024.2; platform_system == "Windows"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 apprise==1.9.0
 ntplib==0.4.0
-pytz==2024.1  # Remove when this script only supports Python 3.9+
 requests==2.32.3
 seleniumbase==4.32.6

--- a/southwest.py
+++ b/southwest.py
@@ -2,7 +2,6 @@
 """Entrypoint into the script where the arguments are passed to lib.main"""
 
 import sys
-from typing import List
 
 __version__ = "v8.1"
 
@@ -33,7 +32,7 @@ def print_usage() -> None:
     print(__doc__)
 
 
-def check_flags(arguments: List[str]) -> None:
+def check_flags(arguments: list[str]) -> None:
     """Checks for version and help flags and exits the script on success"""
     if "--version" in arguments or "-V" in arguments:
         print_version()
@@ -43,7 +42,7 @@ def check_flags(arguments: List[str]) -> None:
         sys.exit()
 
 
-def init(arguments: List[str]) -> None:
+def init(arguments: list[str]) -> None:
     check_flags(arguments)
 
     # Imported here to avoid needing dependencies to retrieve the script's

--- a/tests/integration/test_fare_checker.py
+++ b/tests/integration/test_fare_checker.py
@@ -3,7 +3,6 @@ Runs the fare checker through various scenarios that could happen while checking
 """
 
 import copy
-from typing import List
 from unittest import mock
 
 import pytest
@@ -238,7 +237,7 @@ def test_flight_error_when_no_change_link_exists(
     "fare", [None, [{"_meta": {"fareProductId": "TEST"}}], [{"_meta": {"fareProductId": "WGA"}}]]
 )
 def test_unavailable_fares(
-    requests_mock: RequestMocker, monitor: ReservationMonitor, flight: Flight, fare: List
+    requests_mock: RequestMocker, monitor: ReservationMonitor, flight: Flight, fare: list
 ) -> None:
     flights = copy.deepcopy(FLIGHT_CARDS)
     flights[2]["fares"] = fare

--- a/tests/integration/test_script_set_up.py
+++ b/tests/integration/test_script_set_up.py
@@ -2,7 +2,7 @@
 
 import json
 import logging
-from typing import Iterator
+from collections.abc import Iterator
 
 import pytest
 from pytest_mock import MockerFixture

--- a/tests/unit/test_checkin_scheduler.py
+++ b/tests/unit/test_checkin_scheduler.py
@@ -1,7 +1,6 @@
 import copy
 import json
 from datetime import datetime, timedelta, timezone
-from typing import List
 from unittest import mock
 
 import pytest
@@ -21,7 +20,7 @@ from lib.webdriver import WebDriver
 
 
 @pytest.fixture
-def test_flights(mocker: MockerFixture) -> List[Flight]:
+def test_flights(mocker: MockerFixture) -> list[Flight]:
     mocker.patch.object(Flight, "_set_flight_time")
     flight_info = {
         "departureAirport": {"name": None},
@@ -59,7 +58,7 @@ class TestCheckInScheduler:
         mock_webdriver_set_headers.assert_called_once()
 
     def test_get_flights_retrieves_all_flights_under_reservation(
-        self, mocker: MockerFixture, test_flights: List[Flight]
+        self, mocker: MockerFixture, test_flights: list[Flight]
     ) -> None:
         mocker.patch.object(
             CheckInScheduler, "_get_reservation_info", return_value={"bounds": [{}, {}]}
@@ -89,7 +88,7 @@ class TestCheckInScheduler:
         assert len(flights) == 0, "Flights were retrieved"
 
     def test_get_flights_does_not_retrieve_departed_flights(
-        self, mocker: MockerFixture, test_flights: List[Flight]
+        self, mocker: MockerFixture, test_flights: list[Flight]
     ) -> None:
         mocker.patch.object(
             CheckInScheduler, "_get_reservation_info", return_value={"bounds": [{}, {}]}
@@ -133,7 +132,7 @@ class TestCheckInScheduler:
         assert reservation_info == {}
 
     def test_get_reservation_info_sends_error_when_reservation_retrieval_fails_and_flight_scheduled(
-        self, mocker: MockerFixture, test_flights: List[Flight]
+        self, mocker: MockerFixture, test_flights: list[Flight]
     ) -> None:
         """
         A reservation is already scheduled but fails for a retrieval resulting in another error than
@@ -151,7 +150,7 @@ class TestCheckInScheduler:
         assert reservation_info == {}
 
     def test_get_reservation_info_does_not_send_error_notification_when_reservation_is_old(
-        self, mocker: MockerFixture, test_flights: List[Flight]
+        self, mocker: MockerFixture, test_flights: list[Flight]
     ) -> None:
         """A reservation is already scheduled and the flights are in the past"""
         mocker.patch(
@@ -170,7 +169,7 @@ class TestCheckInScheduler:
 
     @pytest.mark.parametrize(["hour_diff", "same_day"], [(23, True), (24, True), (25, False)])
     def test_set_same_day_flight_sets_flight_as_same_day_correctly(
-        self, hour_diff: int, same_day: bool, test_flights: List[Flight]
+        self, hour_diff: int, same_day: bool, test_flights: list[Flight]
     ) -> None:
         prev_flight, new_flight = test_flights
         prev_flight.departure_time = datetime.now(timezone.utc)
@@ -181,7 +180,7 @@ class TestCheckInScheduler:
         assert new_flight.is_same_day == same_day
 
     def test_update_scheduled_flights_updates_all_flights_correctly(
-        self, mocker: MockerFixture, test_flights: List[Flight]
+        self, mocker: MockerFixture, test_flights: list[Flight]
     ) -> None:
         flight1 = test_flights[0]
         flight2 = test_flights[1]
@@ -208,7 +207,7 @@ class TestCheckInScheduler:
         ), "Cached reservation info for already scheduled flight was never updated"
 
     def test_schedule_flights_schedules_all_flights(
-        self, mocker: MockerFixture, test_flights: List[Flight]
+        self, mocker: MockerFixture, test_flights: list[Flight]
     ) -> None:
         mock_schedule_check_in = mocker.patch.object(CheckInHandler, "schedule_check_in")
         mock_new_flights_notification = mocker.patch.object(NotificationHandler, "new_flights")
@@ -223,7 +222,7 @@ class TestCheckInScheduler:
         mock_new_flights_notification.assert_called_once_with(test_flights)
 
     def test_remove_old_flights_removes_flights_not_currently_scheduled(
-        self, mocker: MockerFixture, test_flights: List[Flight]
+        self, mocker: MockerFixture, test_flights: list[Flight]
     ) -> None:
         test_flights[0].flight_number = "101"
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Union
 
 import pytest
 from pytest_mock import MockerFixture
@@ -8,7 +8,7 @@ from pytest_mock import MockerFixture
 from lib.config import AccountConfig, Config, ConfigError, GlobalConfig, ReservationConfig
 from lib.utils import CheckFaresOption, NotificationLevel
 
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 # This needs to be accessed to be tested
 # pylint: disable=protected-access
@@ -122,7 +122,7 @@ class TestConfig:
         [(["test_url"], ["test_url"]), ("test_url", ["test_url"]), ("", [])],
     )
     def test_parse_config_sets_the_correct_notification_urls(
-        self, notification_urls: Union[List[str], str], expected_urls: [List[str]]
+        self, notification_urls: Union[list[str], str], expected_urls: [list[str]]
     ) -> None:
         test_config = Config()
         test_config._parse_config({"notification_urls": notification_urls})

--- a/tests/unit/test_fare_checker.py
+++ b/tests/unit/test_fare_checker.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List
+from typing import Any, Callable
 
 import pytest
 from pytest_mock import MockerFixture
@@ -14,7 +14,7 @@ from lib.utils import CheckFaresOption, FlightChangeError
 # This needs to be accessed to be tested
 # pylint: disable=protected-access
 
-JSON = Dict[str, Any]
+JSON = dict[str, Any]
 
 
 @pytest.fixture
@@ -151,9 +151,7 @@ class TestFareChecker:
         assert call_args[1] == fare_checker.BOOKING_URL + "test_link"
         assert call_args[3] == "query_body"
 
-    def test_get_change_flight_page_raises_exception_when_flight_cannot_be_changed(
-        self, mocker: MockerFixture
-    ) -> None:
+    def test_get_change_flight_page_raises_exception_when_flight_cannot_be_changed(self) -> None:
         reservation_info = {
             "greyBoxMessage": None,
             "bounds": ["bound_one", "bound_two"],
@@ -290,7 +288,7 @@ class TestFareChecker:
     # An empty list of flights should never be returned from Southwest, but test just in case
     @pytest.mark.parametrize("flights", [[], [{"fares": "fare1"}]])
     def test_get_lowest_fare_returns_zero_when_no_matching_fares(
-        self, mocker: MockerFixture, test_flight: Flight, flights: List[JSON]
+        self, mocker: MockerFixture, test_flight: Flight, flights: list[JSON]
     ) -> None:
         self.checker.filter = fare_checker.any_flight_filter
         mocker.patch.object(FareChecker, "_get_matching_fare", return_value=None)
@@ -316,7 +314,7 @@ class TestFareChecker:
 
     @pytest.mark.parametrize("fares", [None, [], [{"_meta": {"fareProductId": "right_fare"}}]])
     def test_get_matching_fare_returns_nothing_when_price_is_not_available(
-        self, fares: List[JSON]
+        self, fares: list[JSON]
     ) -> None:
         assert self.checker._get_matching_fare(fares, "right_fare") is None
 

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -92,7 +92,7 @@ class TestFlight:
         ],
     )
     def test_flights_with_different_flight_numbers_or_departure_times_are_not_equal(
-        self, mocker: MockerFixture, flight_info: Dict[str, Any], departure_time: datetime
+        self, mocker: MockerFixture, flight_info: dict[str, Any], departure_time: datetime
     ) -> None:
         mocker.patch.object(Flight, "_set_flight_time")
         new_flight = Flight(flight_info, {}, "")
@@ -145,7 +145,7 @@ class TestFlight:
         [(["WN100"], "100"), (["WN100", "WN101"], "100\u200b/\u200b101")],
     )
     def test_get_flight_number_creates_flight_number_correctly(
-        self, numbers: List[str], expected_num: str
+        self, numbers: list[str], expected_num: str
     ) -> None:
         flights = [{"number": num} for num in numbers]
         assert self.flight._get_flight_number(flights) == expected_num

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -1,10 +1,10 @@
-from datetime import datetime
+import zoneinfo
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from unittest import mock
 
 import pytest
-import pytz
 from pytest_mock import MockerFixture
 
 from lib.flight import Flight
@@ -106,8 +106,8 @@ class TestFlight:
     def test_get_display_time_formats_time_correctly(
         self, twenty_four_hr: bool, expected_time: str
     ) -> None:
-        tz = pytz.timezone("Asia/Calcutta")
-        self.flight._local_departure_time = tz.localize(datetime(1999, 12, 31, 13, 59))
+        tz = zoneinfo.ZoneInfo("Asia/Calcutta")
+        self.flight._local_departure_time = datetime(1999, 12, 31, 13, 59, tzinfo=tz)
         assert self.flight.get_display_time(twenty_four_hr) == f"1999-12-31 {expected_time} IST"
 
     def test_set_flight_time_sets_the_correct_time(self, mocker: MockerFixture) -> None:
@@ -130,15 +130,15 @@ class TestFlight:
     def test_get_airport_timezone_returns_the_correct_timezone(self, mocker: MockerFixture) -> None:
         mocker.patch.object(Path, "read_text")
         mocker.patch("json.loads", return_value={"test_code": "Asia/Calcutta"})
-        timezone = self.flight._get_airport_timezone("test_code")
-        assert timezone == pytz.timezone("Asia/Calcutta")
+        tz = self.flight._get_airport_timezone("test_code")
+        assert tz == zoneinfo.ZoneInfo("Asia/Calcutta")
 
     def test_convert_to_utc_converts_local_time_to_utc(self) -> None:
-        tz = pytz.timezone("Asia/Calcutta")
+        tz = zoneinfo.ZoneInfo("Asia/Calcutta")
         utc_flight_time = self.flight._convert_to_utc("1999-12-31 23:59", tz)
 
-        assert utc_flight_time == datetime(1999, 12, 31, 18, 29)
-        assert self.flight._local_departure_time == tz.localize(datetime(1999, 12, 31, 23, 59))
+        assert utc_flight_time == datetime(1999, 12, 31, 18, 29, tzinfo=timezone.utc)
+        assert self.flight._local_departure_time == datetime(1999, 12, 31, 23, 59, tzinfo=tz)
 
     @pytest.mark.parametrize(
         ["numbers", "expected_num"],

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,7 +1,7 @@
 import logging
 import multiprocessing
 import sys
-from typing import Iterator
+from collections.abc import Iterator
 
 import pytest
 from pytest_mock import MockerFixture

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 import pytest
 from pytest_mock import MockerFixture
@@ -77,7 +76,7 @@ def test_set_up_check_in_sends_test_notifications_when_flag_passed(mocker: Mocke
     ],
 )
 def test_set_up_check_in_sets_up_account_and_reservation_with_arguments(
-    mocker: MockerFixture, arguments: List[str], accounts_len: int, reservations_len: int
+    mocker: MockerFixture, arguments: list[str], accounts_len: int, reservations_len: int
 ) -> None:
     mock_process = mocker.patch("multiprocessing.Process")
     mock_processes = [mock_process] * (accounts_len + reservations_len)

--- a/tests/unit/test_southwest.py
+++ b/tests/unit/test_southwest.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 from pytest_mock import MockerFixture
 
@@ -34,7 +32,7 @@ def test_check_flags_prints_version_when_version_flag_is_passed(
 @pytest.mark.parametrize("arguments", [["-h"], ["--help"]])
 def test_check_flags_prints_usage_when_help_flag_is_passed(
     mocker: MockerFixture,
-    arguments: List[str],
+    arguments: list[str],
 ) -> None:
     mock_print_usage = mocker.patch("southwest.print_usage")
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -134,7 +134,7 @@ def test_get_current_time_returns_a_datetime_from_ntp_server(mocker: MockerFixtu
     ntp_stats.tx_timestamp = 3155673599
     mocker.patch("ntplib.NTPClient.request", return_value=ntp_stats)
 
-    assert utils.get_current_time() == datetime(1999, 12, 31, 23, 59, 59)
+    assert utils.get_current_time() == datetime(1999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 
 def test_get_current_time_returns_a_datetime_from_backup_ntp_server(mocker: MockerFixture) -> None:
@@ -142,18 +142,20 @@ def test_get_current_time_returns_a_datetime_from_backup_ntp_server(mocker: Mock
     ntp_stats.tx_timestamp = 3155673599
     mocker.patch("ntplib.NTPClient.request", side_effect=[ntplib.NTPException, ntp_stats])
 
-    assert utils.get_current_time() == datetime(1999, 12, 31, 23, 59, 59)
+    assert utils.get_current_time() == datetime(1999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 
 @pytest.mark.parametrize("exception", [socket.gaierror, ntplib.NTPException])
 def test_get_current_time_returns_local_datetime_on_failed_requests(
     mocker: MockerFixture, exception: Exception
 ) -> None:
+    expected_time = datetime(1999, 12, 31, 18, 59, 59, tzinfo=timezone.utc)
+
     mocker.patch("ntplib.NTPClient.request", side_effect=exception)
     mock_datetime = mocker.patch("lib.utils.datetime")
-    mock_datetime.now.return_value = datetime(1999, 12, 31, 18, 59, 59, tzinfo=timezone.utc)
+    mock_datetime.now.return_value = expected_time
 
-    assert utils.get_current_time() == datetime(1999, 12, 31, 18, 59, 59)
+    assert utils.get_current_time() == expected_time
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -36,6 +36,7 @@ def test_handle_southwest_error_code_handles_all_special_codes(
     response_body = json.dumps({"code": code})
     request_err = RequestError("", response_body)
     with pytest.raises(error):
+        # pylint: disable-next=protected-access
         utils._handle_southwest_error_code(request_err)
 
 

--- a/tests/unit/test_webdriver.py
+++ b/tests/unit/test_webdriver.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from typing import Any, Dict
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -253,7 +253,7 @@ class TestWebDriver:
         ],
     )
     def test_get_needed_headers_returns_matching_headers(
-        self, original_headers: Dict[str, Any], expected_headers: Dict[str, Any]
+        self, original_headers: dict[str, Any], expected_headers: dict[str, Any]
     ) -> None:
         headers = self.driver._get_needed_headers(original_headers)
         assert headers == expected_headers


### PR DESCRIPTION
Since Python 3.8 has officially reached its EOL, support for it is dropped. Additionally, official support for Python 3.13 has been added. Here is a list of specific changes done:
- Built-in types are now used instead of importing them from typing (Dict, List, Tuple) which was added in Python 3.9
- The pytz dependency is removed in favor of the built-in `zoneinfo` module

I have not found a way to upgrade the Dockerfile past `python:3.12-rc-alpine`. If it goes past this tag, the webdriver times out. If I instead switch to an Ubuntu image with `python:3.13-slim`, the script is detected very often. We'll have to stay at an old version until we can figure this out.