### PR TITLE
Allow for more fine-grained configuration for notifications

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -85,8 +85,9 @@ You can also select the level of notifications you want to receive.
 ```
 `Level 1`: Receive notices of skipped reservation retrievals due to driver timeouts and Too Many Requests errors
 during logins as well as all messages in later levels.\
-`Level 2`: Receive successful scheduling and check-in messages, lower fare messages, and all messages in later levels.\
-`Level 3`: Receive only error messages (failed scheduling and check-ins).
+`Level 2`: Receive successful scheduling messages, lower fare messages, and all messages in later levels.\
+`Level 3`: Receive successful check-in messages, and all messages in later levels.\
+`Level 4`: Receive only error messages (failed scheduling and check-ins).
 
 ### Notification 24 Hour Time
 Default: false \

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -11,9 +11,6 @@ reservation-specific configurations).
 ## Table of Contents
 - [Check Fares](#check-fares)
 - [Notifications](#notifications)
-    * [Notification URLs](#notification-urls)
-    * [Notification Level](#notification-level)
-    * [Notification 24 Hour Time](#notification-24-hour-time)
     * [Test The Notifications](#test-the-notifications)
 - [Browser Path](#browser-path)
 - [Retrieval Interval](#retrieval-interval)
@@ -45,44 +42,34 @@ In addition to automatically checking in, flights can be automatically checked f
 - `"same_day"`: Check for lower fares on all flights on the same day as the flight
 
 ## Notifications
-### Notification URLs
 Default: [] \
-Type: String or List \
-Environment Variable: `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_URL`
-> When using the environment variable, you may only specify a single URL.
-> If you are also using `config.json`, it will append the URL as long as it's not a duplicate.
+Type: List \
+Environment Variables:
+- `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_URL`
+- `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_LEVEL`
+- `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_24_HOUR_TIME`
+> When using the environment variable, you may only specify a single URL. If a level or 24-hour time
+> is specified, but no URL is specified, it will have no effect.
+> If you are also using `config.json`, it will add the notification service as long as the URL is not a duplicate.
 
-Users can be notified on successful and failed check-ins. This is done through the [Apprise library].
-To start, first gather the service URL you want to send notifications to (information on how to create
-service URLs can be found on the [Apprise Readme]). Then put it in your configuration file.
+Users can be notified on successful and failed check-ins, flight scheduling, and fare drops. This is done through
+the [Apprise library]. Information on how to create notification URLs can be found on the [Apprise Readme]. You can
+optionally include a [notification level](#notification-level) and [24-hour time](#notification-24-hour-time) setting
+for each notification service you use.
 ```json
 {
-  "notification_urls": "service://my_service_url"
-}
-```
-If you have more than one service you want to send notifications to, you can put them in an array:
-```json
-{
-  "notification_urls": [
-    "service://my_first_service_url",
-    "service://my_second_service_url"
+  "notifications": [
+    {"url": "service://my_first_service_url", "level": 3, "24_hour_time": true},
+    {"url": "service://my_second_service_url"}
   ]
 }
-
 ```
 
 ### Notification Level
 Default: 2 \
-Type: Integer \
-Environment Variable: `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_LEVEL`
-> Using the environment variable will override the applicable setting in `config.json`.
+Type: Integer
 
-You can also select the level of notifications you want to receive.
-```json
-{
-  "notification_level": 2
-}
-```
+The following levels are available: \
 `Level 1`: Receive notices of skipped reservation retrievals due to driver timeouts and Too Many Requests errors
 during logins as well as all messages in later levels.\
 `Level 2`: Receive successful scheduling messages, lower fare messages, and all messages in later levels.\
@@ -91,16 +78,9 @@ during logins as well as all messages in later levels.\
 
 ### Notification 24 Hour Time
 Default: false \
-Type: Boolean \
-Environment Variable: `AUTO_SOUTHWEST_CHECK_IN_NOTIFICATION_24_HOUR_TIME`
-> Using the environment variable will override the applicable setting in `config.json`.
+Type: Boolean
 
 Display flight times in notifications and console messages in 24-hour format instead of 12-hour format.
-```json
-{
-  "notification_24_hour_time": true
-}
-```
 
 ### Test The Notifications
 To test if the notification URLs work, you can run the following command
@@ -187,17 +167,17 @@ and/or not provide reservation information as arguments.
 Setting specific configuration values for an account or reservation allows you to fully customize how you want them to be
 monitored by the script. Here is a list of configuration values that can be applied to an individual account or reservation:
 - [Check Fares](#check-fares)
-- [Healthchecks URL](#healthchecks-url)
-- [Notification URLs](#notification-urls)
-- [Notification Level](#notification-level)
+- [Notifications](#notifications)
 - [Retrieval Interval](#retrieval-interval)
+- [Healthchecks URL](#healthchecks-url)
 
 Not all options have to be specified for each account or reservation. If an option is not specified, the top-level value is used
 (or the default value if no top-level value is specified either) with exception to the Healthchecks URL. Any accounts or reservations
 specified through the command line will use all of the top-level values.
 
-An important note about notification URLs: An account or reservation with specific notification URLs will send notifications to those
-URLs as well as URLs specified globally.
+An important note about notification services: An account or reservation with specific notification services will send notifications to those
+services as well as services specified globally. If a service is in both the global and account/reservation configuration, the account/reservation
+configuration will take precedence.
 
 #### Examples
 Here are a few examples of how the configuration options can be specified:
@@ -217,13 +197,13 @@ In this example, `user1`'s account will not check for lower flight fares. Howeve
 In this example, the script will send notifications attached to this reservation to both `top-level.url` and `my-special.url`.
 ```json
 {
-    "notification_urls": "https://top-level.url",
+    "notifications": [{"url": "https://top-level.url"}],
     "reservations": [
         {
             "confirmationNumber": "num1",
             "firstName": "John",
             "lastName": "Doe",
-            "notification_urls": "https://my-special.url"
+            "notifications": [{"url": "https://my-special.url"}]
         }
     ]
 }

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -80,7 +80,8 @@ during logins as well as all messages in later levels.\
 Default: false \
 Type: Boolean
 
-Display flight times in notifications and console messages in 24-hour format instead of 12-hour format.
+Display flight times in notifications in 24-hour format instead of 12-hour format. Console messages
+will always display in 12-hour format.
 
 ### Test The Notifications
 To test if the notification URLs work, you can run the following command

--- a/config.schema.json
+++ b/config.schema.json
@@ -4,13 +4,7 @@
   "properties": {
     "$schema": {},
     "check_fares": { "$ref": "#/$defs/check_fares" },
-    "notification_urls": { "$ref": "#/$defs/notification_urls" },
-    "notification_level": { "$ref": "#/$defs/notification_level" },
-    "notification_24_hour_time": {
-      "type": "boolean",
-      "description": "Display flight times in notifications and console messages in 24-hour format instead of 12-hour format.",
-      "default": false
-    },
+    "notifications": { "$ref": "#/$defs/notifications" },
     "browser_path": {
       "type": "string",
       "description": "Path to your Chromium-based browser executable (if not using Chrome or Chromium)"
@@ -35,8 +29,7 @@
           },
           "check_fares": { "$ref": "#/$defs/check_fares" },
           "healthchecks_url": { "$ref": "#/$defs/healthchecks_url" },
-          "notification_urls": { "$ref": "#/$defs/notification_urls" },
-          "notification_level": { "$ref": "#/$defs/notification_level" },
+          "notifications": { "$ref": "#/$defs/notifications" },
           "retrieval_interval": { "$ref": "#/$defs/retrieval_interval" }
         },
         "required": ["username", "password"],
@@ -67,8 +60,7 @@
           },
           "check_fares": { "$ref": "#/$defs/check_fares" },
           "healthchecks_url": { "$ref": "#/$defs/healthchecks_url" },
-          "notification_urls": { "$ref": "#/$defs/notification_urls" },
-          "notification_level": { "$ref": "#/$defs/notification_level" },
+          "notifications": { "$ref": "#/$defs/notifications" },
           "retrieval_interval": { "$ref": "#/$defs/retrieval_interval" }
         },
         "required": ["confirmationNumber", "firstName", "lastName"],
@@ -114,6 +106,25 @@
       ],
       "default": true
     },
+    "notifications": {
+      "type": "array",
+      "description": "List of notification services",
+      "default": [],
+      "items": {
+        "type": "object",
+        "properties": {
+          "url": { "$ref": "#/$defs/notification_urls" },
+          "level": { "$ref": "#/$defs/notification_level" },
+          "24_hour_time": {
+            "type": "boolean",
+            "description": "Display flight times in notifications and console messages in 24-hour format instead of 12-hour format.",
+            "default": false
+          }
+        },
+        "required": ["url"],
+        "additionalProperties": false
+      }
+    },
     "notification_urls": {
       "description": "List of notification URLs in the Apprise format",
       "oneOf": [
@@ -142,12 +153,17 @@
         {
           "type": "integer",
           "const": 2,
-          "description": "Level 2: Receive successful scheduling and check-in messages, lower fare messages, and all messages in later levels."
+          "description": "Level 2: Receive successful scheduling messages, lower fare messages, and all messages in later levels."
         },
         {
           "type": "integer",
           "const": 3,
-          "description": "Level 3: Receive only error messages (failed scheduling and check-ins)."
+          "description": "Level 3: Receive successful check-in messages, and all messages in later levels."
+        },
+        {
+          "type": "integer",
+          "const": 4,
+          "description": "Level 4: Receive only error messages (failed scheduling and check-ins)."
         }
       ],
       "default": 2

--- a/lib/checkin_scheduler.py
+++ b/lib/checkin_scheduler.py
@@ -147,8 +147,7 @@ class CheckInScheduler:
             if flight in flights:
                 continue
 
-            # Use 12-hour format time for the user as this is just printed to the console, not sent
-            # in a notification
+            # Print console messages with a 12-hour time format
             flight_time = flight.get_display_time(False)
             print(
                 f"Flight from {flight.departure_airport} to {flight.destination_airport} on "

--- a/lib/checkin_scheduler.py
+++ b/lib/checkin_scheduler.py
@@ -142,20 +142,20 @@ class CheckInScheduler:
         """Remove all scheduled flights that are not in the current flight list"""
         logger.debug("%d flights are currently scheduled. Removing old flights", len(self.flights))
 
-        twenty_four_hr_time = self.reservation_monitor.config.notification_24_hour_time
-
         # Copy the list because it can potentially change inside the loop
         for flight in self.flights[:]:
             if flight in flights:
                 continue
 
-            flight_idx = self.flights.index(flight)
-            flight_time = flight.get_display_time(twenty_four_hr_time)
+            # Use 12-hour format time for the user as this is just printed to the console, not sent
+            # in a notification
+            flight_time = flight.get_display_time(False)
             print(
                 f"Flight from {flight.departure_airport} to {flight.destination_airport} on "
                 f"{flight_time} is no longer scheduled. Stopping its check-in\n"
             )  # Don't log as it has sensitive information
 
+            flight_idx = self.flights.index(flight)
             self.checkin_handlers[flight_idx].stop_check_in()
 
             self.checkin_handlers.pop(flight_idx)

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import sys
@@ -34,7 +36,7 @@ class Config:
         # Cached for easier parsing. Internal only
         self._notification_urls = []
 
-    def create(self, config_json: JSON, global_config: "GlobalConfig" = None) -> None:
+    def create(self, config_json: JSON, global_config: GlobalConfig = None) -> None:
         """
         Create a config by merging any global configurations and then parsing the config JSON.
         Merging is done first so configurations specific to an account and reservation take
@@ -51,7 +53,7 @@ class Config:
         if global_config is not None:
             self.merge_notification_config(global_config)
 
-    def _merge_globals(self, global_config: "GlobalConfig") -> None:
+    def _merge_globals(self, global_config: GlobalConfig) -> None:
         """
         Each account and reservation config inherits the global
         configuration first. If specific options are set for an account
@@ -64,7 +66,7 @@ class Config:
         self.check_fares = global_config.check_fares
         self.retrieval_interval = global_config.retrieval_interval
 
-    def merge_notification_config(self, merging_config: "Config") -> None:
+    def merge_notification_config(self, merging_config: Config) -> None:
         """
         Merge notification configs from another configuration. Only merges notification URLs that
         are not already present in the current configuration.

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -37,8 +37,11 @@ class NotificationHandler:
 
         The flights parameter is necessary so the flight time format of each service is respected.
         """
+        flights = flights or []
 
-        print(body)  # This isn't logged as it contains sensitive information
+        # Print console messages with a 12-hour time format
+        printed_body = self._format_flight_times(body, flights, False)
+        print(printed_body)  # This isn't logged as it contains sensitive information
 
         title = "Auto Southwest Check-in Script"
         flights = flights or []

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -117,7 +117,7 @@ class NotificationHandler:
                     )
 
         logger.debug("Sending successful check-in notification...")
-        self.send_notification(success_message, NotificationLevel.INFO)
+        self.send_notification(success_message, NotificationLevel.CHECKIN)
 
     def failed_checkin(self, error: RequestError, flight: Flight) -> None:
         error_message = (

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -16,6 +16,8 @@ MANUAL_CHECKIN_URL = "https://mobile.southwest.com/check-in"
 MANAGE_RESERVATION_URL_MOBILE = "https://mobile.southwest.com/view-reservation"
 MANAGE_RESERVATION_URL_DESKTOP = "https://www.southwest.com/air/manage-reservation/"
 
+FLIGHT_TIME_PLACEHOLDER = "FLIGHT_TIME"
+
 logger = get_logger(__name__)
 
 
@@ -24,21 +26,55 @@ class NotificationHandler:
 
     def __init__(self, reservation_monitor: Union[AccountMonitor, ReservationMonitor]) -> None:
         self.reservation_monitor = reservation_monitor
-        self.notification_urls = reservation_monitor.config.notification_urls
-        self.notification_level = reservation_monitor.config.notification_level
+        self.notifications = reservation_monitor.config.notifications
 
-    def send_notification(self, body: str, level: NotificationLevel = None) -> None:
+    def send_notification(
+        self, body: str, level: NotificationLevel = None, flights: list[Flight] = None
+    ) -> None:
+        """
+        Send a notification to all configured services. The notification will only be sent if the
+        level of the notification is greater than or equal to the level of the notification service.
+
+        The flights parameter is necessary so the flight time format of each service is respected.
+        """
+
         print(body)  # This isn't logged as it contains sensitive information
 
-        # Check the level to see if we still want to send it. If level is none, it means
-        # the message will always be printed. For example, this is used when testing notifications.
-        if level and level < self.notification_level:
-            return
-
         title = "Auto Southwest Check-in Script"
+        flights = flights or []
 
-        apobj = apprise.Apprise(self.notification_urls)
-        apobj.notify(title=title, body=body, body_format=apprise.NotifyFormat.TEXT)
+        for notification in self.notifications:
+            # Only send the notification to levels that are greater than or equal to the level
+            # of the notification. If level is none, it means the message will always be printed.
+            # For example, this is used when the user tests notifications.
+            if level and level < notification.level:
+                continue
+
+            # Replace any flight time placeholder with the actual flight times, according to the
+            # notification's time format
+            formatted_body = self._format_flight_times(
+                body, flights, notification.twenty_four_hour_time
+            )
+
+            # Send each notification separately, as each message may contain different formatted
+            # flight times
+            apobj = apprise.Apprise(notification.url)
+            apobj.notify(title=title, body=formatted_body, body_format=apprise.NotifyFormat.TEXT)
+
+    def _format_flight_times(
+        self, body: str, flights: list[Flight], twenty_four_hr_time: bool
+    ) -> str:
+        """
+        Replace the flight time placeholder with the actual flight times, converting them to 24-hour
+        time if necessary.
+        """
+        formatted_body = body
+        for flight in flights:
+            formatted_body = formatted_body.replace(
+                FLIGHT_TIME_PLACEHOLDER, flight.get_display_time(twenty_four_hr_time), 1
+            )
+
+        return formatted_body
 
     def new_flights(self, flights: list[Flight]) -> None:
         # Don't send notifications if no new flights are scheduled
@@ -46,16 +82,14 @@ class NotificationHandler:
             return
 
         is_international = False
-        twenty_four_hr_time = self.reservation_monitor.config.notification_24_hour_time
         flight_schedule_message = (
             "Successfully scheduled the following flights to check in for "
             f"{self._get_account_name()}:\n"
         )
         for flight in flights:
-            flight_time = flight.get_display_time(twenty_four_hr_time)
             flight_schedule_message += (
                 f"Flight from {flight.departure_airport} to {flight.destination_airport} on "
-                f"{flight_time}\n"
+                f"{FLIGHT_TIME_PLACEHOLDER}\n"
             )
             if flight.is_international:
                 is_international = True
@@ -69,7 +103,7 @@ class NotificationHandler:
             )
 
         logger.debug("Sending new flights notification")
-        self.send_notification(flight_schedule_message, NotificationLevel.INFO)
+        self.send_notification(flight_schedule_message, NotificationLevel.INFO, flights)
 
     def failed_reservation_retrieval(self, error: RequestError, confirmation_number: str) -> None:
         error_message = (
@@ -137,29 +171,23 @@ class NotificationHandler:
         self.send_notification(error_message, NotificationLevel.ERROR)
 
     def timeout_before_checkin(self, flight: Flight) -> None:
-        twenty_four_hr_time = self.reservation_monitor.config.notification_24_hour_time
-        flight_time = flight.get_display_time(twenty_four_hr_time)
-
         error_message = (
             "Error: Timed out waiting for headers before check-in. Check-in to flight "
-            f"{flight.confirmation_number} for {self._get_account_name()} at {flight_time} may "
-            "fail.\n"
+            f"{flight.confirmation_number} for {self._get_account_name()} at "
+            f"{FLIGHT_TIME_PLACEHOLDER} may fail.\n"
         )
         logger.debug("Sending timeout before check-in notification...")
-        self.send_notification(error_message, NotificationLevel.ERROR)
+        self.send_notification(error_message, NotificationLevel.ERROR, [flight])
 
     def lower_fare(self, flight: Flight, price_info: str) -> None:
-        twenty_four_hr_time = self.reservation_monitor.config.notification_24_hour_time
-        flight_time = flight.get_display_time(twenty_four_hr_time)
-
         message = (
             f"Found lower fare of {price_info} for flight {flight.confirmation_number} "
-            f"from '{flight.departure_airport}' to '{flight.destination_airport}' on {flight_time} "
-            f"for {self._get_account_name()}!\nManage your reservation here: "
-            f"{MANAGE_RESERVATION_URL_MOBILE} or {MANAGE_RESERVATION_URL_DESKTOP}\n"
+            f"from '{flight.departure_airport}' to '{flight.destination_airport}' on "
+            f"{FLIGHT_TIME_PLACEHOLDER} for {self._get_account_name()}!\nManage your reservation "
+            f"here: {MANAGE_RESERVATION_URL_MOBILE} or {MANAGE_RESERVATION_URL_DESKTOP}\n"
         )
         logger.debug("Sending lower fare notification...")
-        self.send_notification(message, NotificationLevel.INFO)
+        self.send_notification(message, NotificationLevel.INFO, [flight])
 
     def healthchecks_success(self, data: str) -> None:
         if self.reservation_monitor.config.healthchecks_url is not None:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -162,7 +162,8 @@ class DriverTimeoutError(Exception):
 class NotificationLevel(IntEnum):
     NOTICE = 1
     INFO = 2
-    ERROR = 3
+    CHECKIN = 3
+    ERROR = 4
 
 
 # Switch to StrEnum when Python 3.10 support is dropped

--- a/tests/integration/test_config.py
+++ b/tests/integration/test_config.py
@@ -4,16 +4,26 @@ import json
 
 from pytest_mock import MockerFixture
 
-from lib.config import GlobalConfig
-from lib.utils import CheckFaresOption
+from lib.config import GlobalConfig, NotificationConfig
+from lib.utils import CheckFaresOption, NotificationLevel
+
+
+def assert_notification_config_matches(
+    notification_config: NotificationConfig,
+    expected_url: str,
+    expected_level: NotificationLevel,
+    expected_24_hr_time: bool,
+) -> None:
+    assert notification_config.url == expected_url
+    assert notification_config.level == expected_level
+    assert notification_config.twenty_four_hour_time is expected_24_hr_time
 
 
 def test_config(mocker: MockerFixture) -> None:
     config = {
         "browser_path": "chrome_path",
         "check_fares": CheckFaresOption.SAME_DAY_NONSTOP,
-        "notification_level": 1,
-        "notification_urls": ["test1.com", "test2.com"],
+        "notifications": [{"url": "test1.com", "level": 1}, {"url": "test2.com"}],
         "retrieval_interval": 16,
         "accounts": [
             {"username": "test_user1", "password": "test_pass1"},
@@ -21,8 +31,7 @@ def test_config(mocker: MockerFixture) -> None:
                 "username": "test_user2",
                 "password": "test_pass2",
                 "check_fares": False,
-                "notification_level": 2,
-                "notification_urls": "test3.com",
+                "notifications": [{"url": "test1.com", "level": 3}, {"url": "test3.com"}],
                 "retrieval_interval": 10,
             },
         ],
@@ -33,8 +42,7 @@ def test_config(mocker: MockerFixture) -> None:
                 "firstName": "Edmond",
                 "lastName": "Dantès",
                 "check_fares": False,
-                "notification_level": 2,
-                "notification_urls": "test4.com",
+                "notifications": [{"url": "test4.com", "24_hour_time": True}],
                 "retrieval_interval": 8,
             },
         ],
@@ -54,19 +62,34 @@ def test_config(mocker: MockerFixture) -> None:
 
     assert account_one.browser_path == "chrome_path"
     assert account_one.check_fares == CheckFaresOption.SAME_DAY_NONSTOP
-    assert account_one.notification_level == 1
-    assert account_one.notification_urls == ["test1.com", "test2.com"]
-    assert account_one.password == "test_pass1"
     assert account_one.retrieval_interval == 16 * 3600
     assert account_one.username == "test_user1"
+    assert account_one.password == "test_pass1"
+
+    assert len(account_one.notifications) == 2
+    assert_notification_config_matches(
+        account_one.notifications[0], "test1.com", NotificationLevel.NOTICE, False
+    )
+    assert_notification_config_matches(
+        account_one.notifications[1], "test2.com", NotificationLevel.INFO, False
+    )
 
     assert account_two.browser_path == "chrome_path"
     assert account_two.check_fares == CheckFaresOption.NO
-    assert account_two.notification_level == 2
-    assert account_two.notification_urls == ["test1.com", "test2.com", "test3.com"]
-    assert account_two.password == "test_pass2"
     assert account_two.retrieval_interval == 10 * 3600
     assert account_two.username == "test_user2"
+    assert account_two.password == "test_pass2"
+
+    assert len(account_two.notifications) == 3
+    assert_notification_config_matches(
+        account_two.notifications[0], "test1.com", NotificationLevel.CHECKIN, False
+    )
+    assert_notification_config_matches(
+        account_two.notifications[1], "test3.com", NotificationLevel.INFO, False
+    )
+    assert_notification_config_matches(
+        account_two.notifications[2], "test2.com", NotificationLevel.INFO, False
+    )
 
     # Check the reservation configurations
     reservation_one = config.reservations[0]
@@ -77,15 +100,30 @@ def test_config(mocker: MockerFixture) -> None:
     assert reservation_one.confirmation_number == "test_num1"
     assert reservation_one.first_name == "Winston"
     assert reservation_one.last_name == "Smith"
-    assert reservation_one.notification_level == 1
-    assert reservation_one.notification_urls == ["test1.com", "test2.com"]
     assert reservation_one.retrieval_interval == 16 * 3600
+
+    assert len(reservation_one.notifications) == 2
+    assert_notification_config_matches(
+        reservation_one.notifications[0], "test1.com", NotificationLevel.NOTICE, False
+    )
+    assert_notification_config_matches(
+        reservation_one.notifications[1], "test2.com", NotificationLevel.INFO, False
+    )
 
     assert reservation_two.browser_path == "chrome_path"
     assert reservation_two.check_fares == CheckFaresOption.NO
     assert reservation_two.confirmation_number == "test_num2"
     assert reservation_two.first_name == "Edmond"
     assert reservation_two.last_name == "Dantès"
-    assert reservation_two.notification_level == 2
-    assert reservation_two.notification_urls == ["test1.com", "test2.com", "test4.com"]
     assert reservation_two.retrieval_interval == 8 * 3600
+
+    assert len(reservation_two.notifications) == 3
+    assert_notification_config_matches(
+        reservation_two.notifications[0], "test4.com", NotificationLevel.INFO, True
+    )
+    assert_notification_config_matches(
+        reservation_two.notifications[1], "test1.com", NotificationLevel.NOTICE, False
+    )
+    assert_notification_config_matches(
+        reservation_two.notifications[2], "test2.com", NotificationLevel.INFO, False
+    )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -73,7 +73,7 @@ class TestConfig:
             {"notification_24_hour_time": "invalid"},
             {"notification_level": "invalid"},
             {"notification_level": -1},
-            {"notification_level": 4},
+            {"notification_level": 5},
             {"notification_urls": None},
             {"retrieval_interval": "invalid"},
         ],
@@ -91,7 +91,7 @@ class TestConfig:
                 "check_fares": CheckFaresOption.SAME_DAY_NONSTOP,
                 "healthchecks_url": "test_healthchecks",
                 "notification_24_hour_time": False,
-                "notification_level": 3,
+                "notification_level": NotificationLevel.ERROR,
                 "notification_urls": "test_url",
                 "retrieval_interval": 30,
             }

--- a/tests/unit/test_notification_handler.py
+++ b/tests/unit/test_notification_handler.py
@@ -2,7 +2,8 @@ import apprise
 import pytest
 from pytest_mock import MockerFixture
 
-from lib.notification_handler import NotificationHandler
+from lib.config import NotificationConfig
+from lib.notification_handler import FLIGHT_TIME_PLACEHOLDER, NotificationHandler
 from lib.utils import NotificationLevel
 
 # This needs to be accessed to be tested
@@ -10,6 +11,15 @@ from lib.utils import NotificationLevel
 
 
 class TestNotificationHandler:
+    def _get_notification_config(self) -> list[NotificationConfig]:
+        notif1 = NotificationConfig()
+        notif1.url = "http://test1"
+        notif1.level = NotificationLevel.INFO
+        notif2 = NotificationConfig()
+        notif2.url = "http://test2"
+        notif2.level = NotificationLevel.ERROR
+        return [notif1, notif2]
+
     @pytest.fixture(autouse=True)
     def notification_handler(self, mocker: MockerFixture) -> None:
         mock_reservation_monitor = mocker.patch("lib.reservation_monitor.ReservationMonitor")
@@ -19,22 +29,47 @@ class TestNotificationHandler:
     def test_send_nofication_does_not_send_notifications_if_level_is_too_low(
         self, mocker: MockerFixture
     ) -> None:
+        mock_apprise = mocker.patch.object(apprise.Apprise, "__init__", return_value=None)
         mock_apprise_notify = mocker.patch.object(apprise.Apprise, "notify")
-        self.handler.notification_level = 2
+        self.handler.notifications = self._get_notification_config()
 
-        self.handler.send_notification("", 1)
-        mock_apprise_notify.assert_not_called()
+        self.handler.send_notification("", NotificationLevel.INFO)
 
-    @pytest.mark.parametrize("level", [2, None])
+        mock_apprise.assert_called_once_with(self.handler.notifications[0].url)
+        mock_apprise_notify.assert_called_once()
+
+    @pytest.mark.parametrize("level", [NotificationLevel.ERROR, None])
     def test_send_notification_sends_notifications_with_the_correct_content(
-        self, mocker: MockerFixture, level: int
+        self, mocker: MockerFixture, level: NotificationLevel
     ) -> None:
+        mock_apprise = mocker.patch.object(apprise.Apprise, "__init__", return_value=None)
         mock_apprise_notify = mocker.patch.object(apprise.Apprise, "notify")
-        self.handler.notification_urls = ["url"]
-        self.handler.notification_level = 1
+        self.handler.notifications = self._get_notification_config()
 
         self.handler.send_notification("test notification", level)
+
+        assert mock_apprise.call_count == 2
+        assert mock_apprise.call_args_list == [
+            mocker.call(self.handler.notifications[0].url),
+            mocker.call(self.handler.notifications[1].url),
+        ]
+
+        assert mock_apprise_notify.call_count == 2
         assert mock_apprise_notify.call_args[1]["body"] == "test notification"
+
+    def test_format_flight_times_replaces_all_flight_times(self, mocker: MockerFixture) -> None:
+        mock_flight1 = mocker.patch("lib.notification_handler.Flight")
+        mock_flight1.get_display_time.return_value = "2021-01-01 00:00 UTC"
+        mock_flight2 = mocker.patch("lib.notification_handler.Flight")
+        mock_flight2.get_display_time.return_value = "2021-01-01 01:00 UTC"
+
+        body = (
+            f"New flight scheduled at {FLIGHT_TIME_PLACEHOLDER} and another new flight scheduled "
+            f"at {FLIGHT_TIME_PLACEHOLDER}"
+        )
+        formatted = self.handler._format_flight_times(body, [mock_flight1, mock_flight2], True)
+        assert "2021-01-01 00:00 UTC" in formatted
+        assert "2021-01-01 01:00 UTC" in formatted
 
     def test_new_flights_sends_no_notification_if_no_flights_exist(
         self, mocker: MockerFixture

--- a/tests/unit/test_notification_handler.py
+++ b/tests/unit/test_notification_handler.py
@@ -105,7 +105,7 @@ class TestNotificationHandler:
             },
             mock_flight,
         )
-        assert mock_send_notification.call_args[0][1] == NotificationLevel.INFO
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.CHECKIN
 
     def test_successful_checkin_does_not_include_notification_for_lap_child(
         self, mocker: MockerFixture
@@ -131,7 +131,7 @@ class TestNotificationHandler:
         )
         assert "John got A1!" in mock_send_notification.call_args[0][0]
         assert "Lap Child" not in mock_send_notification.call_args[0][0]
-        assert mock_send_notification.call_args[0][1] == NotificationLevel.INFO
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.CHECKIN
 
     def test_failed_checkin_sends_error_notification(self, mocker: MockerFixture) -> None:
         mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")


### PR DESCRIPTION
Closes #280.

This PR adds a **breaking** change to notification services that allow you to specify levels and 24-hour time formats for each individual service instead of having one per account/reservation. Information on how to adapt your configuration will be included in the Changelog (after this PR is merged). The new notification configuration can be found in CONFIGURATION.md.

Additionally, a new notification level was added to allow users to only be notified on successful check-ins and errors (not fare drops or successful flight scheduling).