### PR TITLE
Set timezone for Docker container to fix 403/429 errors

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -16,7 +16,7 @@ CONFIG_FILE_NAME = "config.json"
 logger = get_logger(__name__)
 
 # This environment variable is set in the Docker image
-is_docker = os.environ.get("AUTO_SOUTHWEST_CHECK_IN_DOCKER") == "1"
+IS_DOCKER = os.environ.get("AUTO_SOUTHWEST_CHECK_IN_DOCKER") == "1"
 
 
 # A custom exception for type or value errors in the configuration file

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,6 +15,9 @@ JSON = dict[str, Any]
 CONFIG_FILE_NAME = "config.json"
 logger = get_logger(__name__)
 
+# This environment variable is set in the Docker image
+is_docker = os.environ.get("AUTO_SOUTHWEST_CHECK_IN_DOCKER") == "1"
+
 
 # A custom exception for type or value errors in the configuration file
 class ConfigError(Exception):

--- a/lib/main.py
+++ b/lib/main.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 import multiprocessing
+import os
 import sys
+
+import requests
 
 from lib import log
 
-from .config import GlobalConfig, ReservationConfig
+from .config import GlobalConfig, ReservationConfig, is_docker
 from .reservation_monitor import AccountMonitor, ReservationMonitor
 
 LOG_FILE = "logs/auto-southwest-check-in.log"
+IP_TIMEZONE_URL = "https://ipinfo.io/timezone"
 
 logger = log.get_logger(__name__)
 
@@ -101,9 +105,24 @@ def set_up_check_in(arguments: list[str]) -> None:
         process.join()
 
 
+def get_timezone() -> str:
+    """Fetches the local timezone based on the system's IP address"""
+    try:
+        response = requests.get(IP_TIMEZONE_URL, timeout=5)
+        response.raise_for_status()
+        return response.text.strip()
+    except requests.RequestException:
+        return "UTC"  # Fallback to UTC if the request fails
+
+
 def main(arguments: list[str], version: str) -> None:
     log.init_main_logging()
     logger.debug("Auto-Southwest Check-In %s", version)
+
+    if is_docker:
+        timezone = get_timezone()
+        os.environ["TZ"] = timezone
+        logger.debug(f"Docker timezone: '{timezone}'")
 
     # Remove flags now that they are not needed (and will mess up parsing)
     flags_to_remove = ["--debug-screenshots", "-v", "--verbose"]

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -11,7 +11,7 @@ from sbvirtualdisplay import Display
 from seleniumbase import Driver
 from seleniumbase.fixtures import page_actions as seleniumbase_actions
 
-from .config import is_docker
+from .config import IS_DOCKER
 from .log import LOGS_DIRECTORY, get_logger
 from .utils import DriverTimeoutError, LoginError, random_sleep_duration
 
@@ -137,7 +137,7 @@ class WebDriver:
         browser_path = self.checkin_scheduler.reservation_monitor.config.browser_path
 
         driver_version = "mlatest"
-        if is_docker:
+        if IS_DOCKER:
             self._start_display()
             # Make sure a new driver is not downloaded as the Docker image
             # already has the correct driver
@@ -146,8 +146,8 @@ class WebDriver:
         driver = Driver(
             binary_location=browser_path,
             driver_version=driver_version,
-            headed=is_docker,
-            headless=not is_docker,
+            headed=IS_DOCKER,
+            headless=not IS_DOCKER,
             uc_cdp_events=True,
             undetectable=True,
             incognito=True,

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -11,6 +11,7 @@ from sbvirtualdisplay import Display
 from seleniumbase import Driver
 from seleniumbase.fixtures import page_actions as seleniumbase_actions
 
+from .config import is_docker
 from .log import LOGS_DIRECTORY, get_logger
 from .utils import DriverTimeoutError, LoginError, random_sleep_duration
 
@@ -135,9 +136,6 @@ class WebDriver:
         logger.debug("Starting webdriver for current session")
         browser_path = self.checkin_scheduler.reservation_monitor.config.browser_path
 
-        # This environment variable is set in the Docker image
-        is_docker = os.environ.get("AUTO_SOUTHWEST_CHECK_IN_DOCKER") == "1"
-
         driver_version = "mlatest"
         if is_docker:
             self._start_display()
@@ -153,7 +151,6 @@ class WebDriver:
             uc_cdp_events=True,
             undetectable=True,
             incognito=True,
-            mobile=True,
         )
         logger.debug("Using browser version: %s", driver.caps["browserVersion"])
 


### PR DESCRIPTION
Added timezone handling for Docker container
Moved `is_docker` from webdriver.py to config.py