### PR TITLE
Add notifications for flights eligible to free changes

### DIFF
--- a/lib/checkin_scheduler.py
+++ b/lib/checkin_scheduler.py
@@ -129,6 +129,8 @@ class CheckInScheduler:
 
     def _schedule_flights(self, flights: list[Flight]) -> None:
         logger.debug("Scheduling %d flights for check-in", len(flights))
+
+        reacommodated_flights = []
         for flight in flights:
             checkin_handler = CheckInHandler(self, flight, self.reservation_monitor.lock)
             checkin_handler.schedule_check_in()
@@ -136,7 +138,11 @@ class CheckInScheduler:
             self.flights.append(flight)
             self.checkin_handlers.append(checkin_handler)
 
+            if flight.can_be_reaccommodated:
+                reacommodated_flights.append(flight)
+
         self.notification_handler.new_flights(flights)
+        self.notification_handler.reaccommodated_flights(reacommodated_flights)
 
     def _remove_old_flights(self, flights: list[Flight]) -> None:
         """Remove all scheduled flights that are not in the current flight list"""

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -94,6 +94,11 @@ class FareChecker:
         # Next, get the search information needed to change the flight
         logger.debug("Retrieving search information for the current flight")
         change_link = reservation_info["_links"]["change"]
+        reaccom_link = reservation_info["_links"]["reaccom"]
+
+        if reaccom_link is not None:
+            # The flight is reaccommodated, so changing the flight is not supported
+            raise FlightChangeError("Flight can be changed for free (reaccommodated)")
 
         # The change link does not exist, so skip fare checking for this flight
         if change_link is None:

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -97,7 +97,7 @@ class FareChecker:
         reaccom_link = reservation_info["_links"]["reaccom"]
 
         if reaccom_link is not None:
-            # The flight is reaccommodated, so changing the flight is not supported
+            # The flight is reaccommodated, so no fare checking is needed
             raise FlightChangeError("Flight can be changed for free (reaccommodated)")
 
         # The change link does not exist, so skip fare checking for this flight

--- a/lib/flight.py
+++ b/lib/flight.py
@@ -24,10 +24,8 @@ class Flight:
         self.departure_airport = flight_info["departureAirport"]["name"]
         self.destination_airport = flight_info["arrivalAirport"]["name"]
         self.flight_number = self._get_flight_number(flight_info["flights"])
-        self.is_same_day = False
-
-        # Cached for use by the fare checker
         self.reservation_info = reservation_info
+        self.is_same_day = False
 
         # Track to notify the user of filling out their passport information.
         # Southwest only fills the country's value for international flights
@@ -44,6 +42,13 @@ class Flight:
             and self.flight_number == other.flight_number
             and self.departure_time == other.departure_time
         )
+
+    @property
+    def can_be_reaccommodated(self) -> bool:
+        """
+        Returns whether or not the flight can be changed for free (Southwest uses 'reaccommodated').
+        """
+        return self.reservation_info["_links"]["reaccom"] is not None
 
     def get_display_time(self, twenty_four_hr_time: bool) -> str:
         if twenty_four_hr_time:

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -112,19 +112,19 @@ class NotificationHandler:
         if len(flights) == 0:
             return
 
-        flight_schedule_message = (
+        flight_reaccommodation_message = (
             "The following flights are eligible to be changed at no cost for "
             f"{self._get_account_name()}!\nManage your reservations here: "
             f"{MANAGE_RESERVATION_URL}\n"
         )
         for flight in flights:
-            flight_schedule_message += (
+            flight_reaccommodation_message += (
                 f"Flight from {flight.departure_airport} to {flight.destination_airport} on "
                 f"{FLIGHT_TIME_PLACEHOLDER}\n"
             )
 
         logger.debug("Sending reaccommodated flights notification")
-        self.send_notification(flight_schedule_message, NotificationLevel.INFO, flights)
+        self.send_notification(flight_reaccommodation_message, NotificationLevel.INFO, flights)
 
     def failed_reservation_retrieval(self, error: RequestError, confirmation_number: str) -> None:
         error_message = (

--- a/lib/notification_handler.py
+++ b/lib/notification_handler.py
@@ -107,6 +107,25 @@ class NotificationHandler:
         logger.debug("Sending new flights notification")
         self.send_notification(flight_schedule_message, NotificationLevel.INFO, flights)
 
+    def reaccommodated_flights(self, flights: list[Flight]) -> None:
+        # Don't send notifications if no flights can be reaccommodated
+        if len(flights) == 0:
+            return
+
+        flight_schedule_message = (
+            "The following flights are eligible to be changed at no cost for "
+            f"{self._get_account_name()}!\nManage your reservations here: "
+            f"{MANAGE_RESERVATION_URL}\n"
+        )
+        for flight in flights:
+            flight_schedule_message += (
+                f"Flight from {flight.departure_airport} to {flight.destination_airport} on "
+                f"{FLIGHT_TIME_PLACEHOLDER}\n"
+            )
+
+        logger.debug("Sending reaccommodated flights notification")
+        self.send_notification(flight_schedule_message, NotificationLevel.INFO, flights)
+
     def failed_reservation_retrieval(self, error: RequestError, confirmation_number: str) -> None:
         error_message = (
             f"Error: Failed to retrieve reservation for {self._get_account_name()} "

--- a/tests/integration/test_fare_checker.py
+++ b/tests/integration/test_fare_checker.py
@@ -114,7 +114,7 @@ def flight() -> Flight:
 
     reservation_info = {
         "bounds": [flight_info],
-        "_links": {"change": {"href": "change_page", "query": "test_query"}},
+        "_links": {"change": {"href": "change_page", "query": "test_query"}, "reaccom": None},
         "greyBoxMessage": None,
     }
     return Flight(flight_info, reservation_info, "TEST")

--- a/tests/integration/test_monitoring_and_scheduling.py
+++ b/tests/integration/test_monitoring_and_scheduling.py
@@ -66,6 +66,9 @@ def test_flight_is_scheduled_checks_in_and_departs(
     mock_new_flights_notification = mocker.patch(
         "lib.notification_handler.NotificationHandler.new_flights"
     )
+    mock_reaccommodated_flights_notification = mocker.patch(
+        "lib.notification_handler.NotificationHandler.reaccommodated_flights"
+    )
     mocker.patch("os.kill")
     mock_sleep = mocker.patch("time.sleep")
 
@@ -95,6 +98,7 @@ def test_flight_is_scheduled_checks_in_and_departs(
                     "flights": [{"number": "WN100"}, {"number": "WN101"}],
                 },
             ],
+            "_links": {"reaccom": None},
         }
     }
 
@@ -121,6 +125,7 @@ def test_flight_is_scheduled_checks_in_and_departs(
     # Ensure the flight was scheduled correctly
     mock_process.start.assert_called_once()
     assert mock_new_flights_notification.call_count == 2
+    assert mock_reaccommodated_flights_notification.call_count == 2
 
     # Ensure the flight was removed after it departed
     assert len(scheduler.checkin_handlers) == 0
@@ -210,6 +215,7 @@ def test_account_schedules_new_flights(requests_mock: RequestMocker, mocker: Moc
                     "flights": [{"number": "WN101"}],
                 },
             ],
+            "_links": {"reaccom": None},
         }
     }
 

--- a/tests/unit/test_flight.py
+++ b/tests/unit/test_flight.py
@@ -97,6 +97,18 @@ class TestFlight:
         assert self.flight != new_flight
 
     @pytest.mark.parametrize(
+        ("reaccom_url", "expected_val"),
+        [(None, False), ({"href": "/test"}, True)],
+    )
+    def test_flight_can_be_reaccomodated(
+        self, mocker: MockerFixture, reaccom_url: str, expected_val: bool
+    ) -> None:
+        mocker.patch.object(Flight, "_set_flight_time")
+        self.flight.reservation_info = {"_links": {"reaccom": reaccom_url}}
+
+        assert self.flight.can_be_reaccommodated == expected_val
+
+    @pytest.mark.parametrize(
         ("twenty_four_hr", "expected_time"), [(True, "13:59"), (False, "1:59 PM")]
     )
     def test_get_display_time_formats_time_correctly(

--- a/tests/unit/test_notification_handler.py
+++ b/tests/unit/test_notification_handler.py
@@ -92,6 +92,22 @@ class TestNotificationHandler:
         self.handler.new_flights([mock_flight])
         assert "passport information" in mock_send_notification.call_args[0][0]
 
+    def test_reaccommodated_flights_sends_no_notification_if_no_flights_are_reaccommodated(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
+        self.handler.reaccommodated_flights([])
+        mock_send_notification.assert_not_called()
+
+    def test_reaccommodated_flights_sends_notifications_for_reaccommodated_flights(
+        self, mocker: MockerFixture
+    ) -> None:
+        mock_send_notification = mocker.patch.object(NotificationHandler, "send_notification")
+        mock_flight = mocker.patch("lib.flight.Flight")
+
+        self.handler.reaccommodated_flights([mock_flight])
+        assert mock_send_notification.call_args[0][1] == NotificationLevel.INFO
+
     def test_failed_reservation_retrieval_sends_error_notification(
         self, mocker: MockerFixture
     ) -> None:


### PR DESCRIPTION
Fixes #339. Users will now be notified when their flights are eligible to be changed for free (see https://support.southwest.com/helpcenter/s/article/options-if-southwest-changes-my-flight). These notifications are sent right after flights are scheduled and will therefore only happen every time a flight is scheduled (not every time a fare check is done).

There is currently no config option to turn this off, but I will add it if some people don't want to receive this notification.

An example notification looks like:
```
Auto Southwest Check-in Script
The following flights are eligible to be changed at no cost for XXX XXX!
Manage your reservations here: https://www.southwest.com/air/manage-reservation/
Flight from XXX to YYY on 2025-01-01 12:00 AM UTC
Flight from YYY to XXX on 2025-01-02 12:00 AM UTC
```