### PR TITLE
Fix fare checking for basic fares

### DIFF
--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable
 
 from .log import get_logger
 from .utils import CheckFaresOption, FlightChangeError, make_request, time
+from .webdriver import WebDriver
 
 if TYPE_CHECKING:
     from .flight import Flight
@@ -21,7 +23,8 @@ class FareChecker:
         self.reservation_monitor = reservation_monitor
         self.headers = reservation_monitor.checkin_scheduler.headers
         self.filter = get_fare_check_filter(self.reservation_monitor.config.check_fares)
-        self._cancel_refund_cache = {}
+        self._original_fare_cache = {}
+        self._points_transactions_cache = {}
 
     def check_flight_price(self, flight: Flight) -> None:
         """
@@ -91,10 +94,6 @@ class FareChecker:
 
     def _get_change_flight_page(self, reservation_info: JSON) -> tuple[JSON, list[JSON]]:
         fare_type_bounds = reservation_info["bounds"]
-
-        # Ensure the flight does not have a companion pass connected to it
-        # as companion passes are not supported.
-        self._check_for_companion(reservation_info)
 
         # Next, get the search information needed to change the flight
         logger.debug("Retrieving search information for the current flight")
@@ -314,19 +313,104 @@ class FareChecker:
             return None
 
         cache_key = (flight.confirmation_number, flight.flight_number, currency_code)
-        if cache_key in self._cancel_refund_cache:
-            return self._cancel_refund_cache[cache_key]
+        if cache_key in self._original_fare_cache:
+            return self._original_fare_cache[cache_key]
 
-        try:
-            original_fare = self._get_cancel_refund_total(flight, currency_code)
-        except (FlightChangeError, KeyError, ValueError) as err:
-            logger.debug(
-                "Could not retrieve WGA refund quote for %s: %s", flight.flight_number, err
-            )
-            original_fare = None
+        original_fare = None
+        if currency_code == "PTS":
+            try:
+                original_fare = self._get_original_wga_points_fare(flight)
+            except (FlightChangeError, KeyError, ValueError, RuntimeError) as err:
+                logger.debug(
+                    "Could not retrieve WGA points activity for %s: %s", flight.flight_number, err
+                )
+        else:
+            try:
+                original_fare = self._get_cancel_refund_total(flight, currency_code)
+            except (FlightChangeError, KeyError, ValueError) as err:
+                logger.debug(
+                    "Could not retrieve WGA refund quote for %s: %s", flight.flight_number, err
+                )
 
-        self._cancel_refund_cache[cache_key] = original_fare
+        self._original_fare_cache[cache_key] = original_fare
         return original_fare
+
+    def _get_original_wga_points_fare(self, flight: Flight) -> JSON | None:
+        transactions = self._get_points_transactions()
+        if transactions is None:
+            return None
+
+        matching_transaction = self._match_points_redemption_transaction(flight, transactions)
+        if matching_transaction is None:
+            return None
+
+        points_detail = matching_transaction["points_detail"]["transaction_points"]
+        return {"amount": int(points_detail["amount"].replace(",", "")), "currencyCode": "PTS"}
+
+    def _get_points_transactions(self) -> list[JSON] | None:
+        if not hasattr(self.reservation_monitor, "username") or not hasattr(
+            self.reservation_monitor, "password"
+        ):
+            return None
+
+        today = datetime.now(timezone.utc).date()
+        start_at = (today - timedelta(days=365)).isoformat()
+        end_at = today.isoformat()
+        cache_key = (start_at, end_at)
+        if cache_key not in self._points_transactions_cache:
+            webdriver = WebDriver(self.reservation_monitor.checkin_scheduler)
+            transactions = webdriver.get_points_transactions(
+                self.reservation_monitor, start_at, end_at
+            )
+            self._points_transactions_cache[cache_key] = transactions.get("data", [])
+
+        return self._points_transactions_cache[cache_key]
+
+    def _match_points_redemption_transaction(
+        self, flight: Flight, transactions: list[JSON]
+    ) -> JSON | None:
+        bound = self._get_matching_bound_info(flight)
+        if bound is None:
+            return None
+
+        departure_date = bound["departureDate"]
+        origin_code = bound["departureAirport"]["code"]
+        destination_code = bound["arrivalAirport"]["code"]
+
+        matching_transactions = []
+        for transaction in transactions:
+            flight_details = transaction.get("flight_details") or {}
+            points_detail = transaction.get("points_detail", {}).get("transaction_points", {})
+            if (
+                transaction.get("product_category") == "FLIGHT"
+                and transaction.get("transaction_type") == "REDEEM"
+                and points_detail.get("currency") == "PTS"
+                and flight_details.get("record_locator") == flight.confirmation_number
+                and flight_details.get("origination_airport_code") == origin_code
+                and flight_details.get("destination_airport_code") == destination_code
+                and (flight_details.get("depart_at") or "").startswith(departure_date)
+            ):
+                matching_transactions.append(transaction)
+
+        if not matching_transactions:
+            return None
+
+        return max(matching_transactions, key=lambda transaction: transaction.get("transaction_at", ""))
+
+    def _get_matching_bound_info(self, flight: Flight) -> JSON | None:
+        for bound in flight.reservation_info["bounds"]:
+            if self._get_bound_flight_number(bound) == flight.flight_number:
+                return bound
+
+        return None
+
+    def _get_bound_flight_number(self, bound: JSON) -> str:
+        flight_number = ""
+        for flight in bound["flights"]:
+            flight_number += flight["number"].removeprefix("WN")
+            flight_number += "\u200b/\u200b"
+
+        return flight_number.rstrip("/\u200b")
 
     def _get_wga_currency(self, flight: Flight, flights: list[JSON]) -> str | None:
         for new_flight in flights:

--- a/lib/fare_checker.py
+++ b/lib/fare_checker.py
@@ -21,6 +21,7 @@ class FareChecker:
         self.reservation_monitor = reservation_monitor
         self.headers = reservation_monitor.checkin_scheduler.headers
         self.filter = get_fare_check_filter(self.reservation_monitor.config.check_fares)
+        self._cancel_refund_cache = {}
 
     def check_flight_price(self, flight: Flight) -> None:
         """
@@ -46,7 +47,11 @@ class FareChecker:
         flights, fare_type = self._get_matching_flights(flight)
         logger.debug("Found %d matching flights", len(flights))
 
-        lowest_fare = self._get_lowest_fare(flight, flights, fare_type)
+        original_fare = None
+        if fare_type.startswith("WGA"):
+            original_fare = self._get_original_wga_fare(flight, flights)
+
+        lowest_fare = self._get_lowest_fare(flight, flights, fare_type, original_fare)
         return lowest_fare
 
     def _get_matching_flights(self, flight: Flight) -> tuple[list[JSON], str]:
@@ -139,7 +144,13 @@ class FareChecker:
         if grey_box_message and "companion" in (grey_box_message.get("body") or ""):
             raise FlightChangeError("Fare check is not supported with companion passes")
 
-    def _get_lowest_fare(self, flight: Flight, flights: list[JSON], fare_type: str) -> JSON:
+    def _get_lowest_fare(
+        self,
+        flight: Flight,
+        flights: list[JSON],
+        fare_type: str,
+        original_fare: JSON | None = None,
+    ) -> JSON:
         """
         Get the lowest fare for the queried flights based on the filter being used. If no fare is
         available for the specific fare type, a 0 USD difference will be returned.
@@ -149,7 +160,7 @@ class FareChecker:
         for new_flight in flights:
             # Only compare flight fares that match the current filter
             if self.filter(flight, new_flight):
-                fare = self._get_matching_fare(new_flight["fares"], fare_type)
+                fare = self._get_matching_fare(new_flight["fares"], fare_type, original_fare)
                 # Check if this fare is the lowest encountered so far
                 if not lowest_fare or (fare and fare["amount"] < lowest_fare["amount"]):
                     lowest_fare = fare
@@ -162,7 +173,9 @@ class FareChecker:
 
         return lowest_fare
 
-    def _get_matching_fare(self, fares: list[JSON], fare_type: str) -> JSON | None:
+    def _get_matching_fare(
+        self, fares: list[JSON], fare_type: str, original_fare: JSON | None = None
+    ) -> JSON | None:
         """
         Get the fare that matches the fare type. If a fare exists, the amount will be returned, as
         an integer, and the currency code (USD or points). If no fare exists, nothing will be
@@ -174,15 +187,223 @@ class FareChecker:
         for fare in fares:
             if fare["_meta"]["fareProductId"] == fare_type:
                 if "priceDifference" in fare:
-                    flight_price = fare["priceDifference"]
-                    # Format the amount correctly
-                    sign = flight_price.get("sign", "")
-                    parsed_amount = int(sign + flight_price["amount"].replace(",", ""))
-                    return {"amount": parsed_amount, "currencyCode": flight_price["currencyCode"]}
+                    return self._parse_amount(fare["priceDifference"])
 
                 break
 
+        if fare_type.startswith("WGA"):
+            return self._get_basic_fare_difference(fares, original_fare)
+
         return None
+
+    def _get_basic_fare_difference(
+        self, fares: list[JSON], original_fare: JSON | None = None
+    ) -> JSON | None:
+        """
+        Basic fares can be unavailable on the change page even when the flight can still be
+        cancelled and rebooked more cheaply. If the originally paid fare is available from the
+        cancel flow, derive the current Basic fare using the available upgrade fares:
+
+            current basic fare = current upgrade fare - displayed price difference
+
+        Otherwise, derive the originally paid fare from an available upgrade fare using:
+
+            paid fare = current fare price - displayed price difference
+
+        Then compare the cheapest current Basic fare against the originally paid fare.
+        """
+        if original_fare is None:
+            original_fare = self._derive_original_basic_fare(fares)
+
+        if original_fare is None:
+            return None
+
+        lowest_current_basic_fare = self._get_lowest_current_basic_fare(
+            fares, original_fare["currencyCode"]
+        )
+        if lowest_current_basic_fare is None:
+            return None
+
+        return {
+            "amount": lowest_current_basic_fare["amount"] - original_fare["amount"],
+            "currencyCode": lowest_current_basic_fare["currencyCode"],
+        }
+
+    def _derive_original_basic_fare(self, fares: list[JSON]) -> JSON | None:
+        original_basic_fare = None
+        for fare in fares:
+            current_price = self._get_fare_price(fare)
+            price_difference = fare.get("priceDifference")
+
+            if current_price is None or price_difference is None:
+                continue
+
+            parsed_current_price = self._parse_amount(current_price)
+            parsed_difference = self._parse_amount(price_difference)
+            if parsed_current_price["currencyCode"] != parsed_difference["currencyCode"]:
+                continue
+
+            calculated_original_price = {
+                "amount": parsed_current_price["amount"] - parsed_difference["amount"],
+                "currencyCode": parsed_current_price["currencyCode"],
+            }
+
+            if original_basic_fare is None:
+                original_basic_fare = calculated_original_price
+
+        return original_basic_fare
+
+    def _get_lowest_available_fare(
+        self, fares: list[JSON], currency_code: str | None = None
+    ) -> JSON | None:
+        lowest_available_fare = None
+        for fare in fares:
+            current_price = self._get_fare_price(fare)
+            if current_price is None:
+                continue
+
+            parsed_current_price = self._parse_amount(current_price)
+            if currency_code and parsed_current_price["currencyCode"] != currency_code:
+                continue
+
+            if (
+                lowest_available_fare is None
+                or parsed_current_price["amount"] < lowest_available_fare["amount"]
+            ):
+                lowest_available_fare = parsed_current_price
+
+        return lowest_available_fare
+
+    def _get_lowest_current_basic_fare(
+        self, fares: list[JSON], currency_code: str | None = None
+    ) -> JSON | None:
+        lowest_current_basic_fare = None
+
+        for fare in fares:
+            current_price = self._get_fare_price(fare)
+            price_difference = fare.get("priceDifference")
+
+            if current_price is None or price_difference is None:
+                continue
+
+            parsed_current_price = self._parse_amount(current_price)
+            parsed_difference = self._parse_amount(price_difference)
+
+            if parsed_current_price["currencyCode"] != parsed_difference["currencyCode"]:
+                continue
+
+            if currency_code and parsed_current_price["currencyCode"] != currency_code:
+                continue
+
+            current_basic_fare = {
+                "amount": parsed_current_price["amount"] - parsed_difference["amount"],
+                "currencyCode": parsed_current_price["currencyCode"],
+            }
+
+            if (
+                lowest_current_basic_fare is None
+                or current_basic_fare["amount"] < lowest_current_basic_fare["amount"]
+            ):
+                lowest_current_basic_fare = current_basic_fare
+
+        return lowest_current_basic_fare
+
+    def _get_original_wga_fare(self, flight: Flight, flights: list[JSON]) -> JSON | None:
+        currency_code = self._get_wga_currency(flight, flights)
+        if currency_code is None:
+            return None
+
+        cache_key = (flight.confirmation_number, flight.flight_number, currency_code)
+        if cache_key in self._cancel_refund_cache:
+            return self._cancel_refund_cache[cache_key]
+
+        try:
+            original_fare = self._get_cancel_refund_total(flight, currency_code)
+        except (FlightChangeError, KeyError, ValueError) as err:
+            logger.debug(
+                "Could not retrieve WGA refund quote for %s: %s", flight.flight_number, err
+            )
+            original_fare = None
+
+        self._cancel_refund_cache[cache_key] = original_fare
+        return original_fare
+
+    def _get_wga_currency(self, flight: Flight, flights: list[JSON]) -> str | None:
+        for new_flight in flights:
+            if self.filter(flight, new_flight):
+                lowest_fare = self._get_lowest_available_fare(new_flight.get("fares") or [])
+                if lowest_fare is not None:
+                    return lowest_fare["currencyCode"]
+
+        return None
+
+    def _get_cancel_refund_total(self, flight: Flight, currency_code: str) -> JSON | None:
+        refund_quote_page = self._get_cancel_refund_quote_page(flight.reservation_info)
+        self._validate_cancel_refund_quote(refund_quote_page, flight)
+
+        for trip_total in refund_quote_page.get("tripTotals") or []:
+            if trip_total["currencyCode"] == currency_code:
+                return self._parse_amount(trip_total)
+
+        return None
+
+    def _get_cancel_refund_quote_page(self, reservation_info: JSON) -> JSON:
+        cancel_page = self._get_cancel_bound_page(reservation_info)
+        refund_quote_link = cancel_page["_links"]["refundQuote"]
+        site = BOOKING_URL + refund_quote_link["href"]
+
+        logger.debug("Retrieving refund quote information for the current flight")
+        time.sleep(2)
+
+        response = make_request(
+            refund_quote_link["method"],
+            site,
+            self.headers,
+            refund_quote_link.get("body", {}),
+            max_attempts=7,
+        )
+        return response["cancelRefundQuotePage"]
+
+    def _get_cancel_bound_page(self, reservation_info: JSON) -> JSON:
+        self._check_for_companion(reservation_info)
+
+        cancel_link = reservation_info["_links"].get("cancelBound")
+        if cancel_link is None:
+            raise FlightChangeError("Flight cannot be cancelled online")
+
+        site = BOOKING_URL + cancel_link["href"]
+        time.sleep(2)
+
+        response = make_request(
+            cancel_link["method"],
+            site,
+            self.headers,
+            cancel_link.get("query", {}),
+            max_attempts=7,
+        )
+        return response["viewForCancelBoundPage"]
+
+    def _validate_cancel_refund_quote(self, refund_quote_page: JSON, flight: Flight) -> None:
+        cancel_bounds = refund_quote_page.get("cancelBounds") or []
+        matching_bounds = [
+            bound for bound in cancel_bounds if bound.get("flight") == flight.flight_number
+        ]
+
+        if len(matching_bounds) != 1 or len(cancel_bounds) != 1:
+            raise FlightChangeError("Could not determine the refund quote for the exact flight")
+
+    def _get_fare_price(self, fare: JSON) -> JSON | None:
+        for price_key in ["discountedPrice", "price"]:
+            price = fare.get(price_key)
+            if price is not None:
+                return price
+
+        return None
+
+    def _parse_amount(self, price_info: JSON) -> JSON:
+        sign = price_info.get("sign", "")
+        parsed_amount = int(sign + price_info["amount"].replace(",", ""))
+        return {"amount": parsed_amount, "currencyCode": price_info["currencyCode"]}
 
 
 def get_fare_check_filter(check_fares: CheckFaresOption) -> Callable[[Flight, JSON], bool]:

--- a/lib/webdriver.py
+++ b/lib/webdriver.py
@@ -22,10 +22,15 @@ if TYPE_CHECKING:
 # URLs for the normal website
 BASE_URL = "https://www.southwest.com"
 ACCOUNT_URL = BASE_URL + "/loyalty/myaccount"
+RAPID_REWARDS_URL = ACCOUNT_URL + "/rapid-rewards"
 SUCCESSFUL_LOGIN_URL = BASE_URL + "/api/security/v4/security/token"
 TRIPS_URL = (
     BASE_URL
     + "/api/loyalty-management/v2/loyalty-management/accounts/self/future-air-reservations-secure"
+)
+POINTS_TRANSACTIONS_URL = (
+    BASE_URL
+    + "/api/loyalty-management/v2/loyalty-management/accounts/self/points-transactions-secure"
 )
 
 # URLs for the mobile website
@@ -140,6 +145,33 @@ class WebDriver:
 
         self._quit_driver(driver)
         return reservations
+
+    def get_points_transactions(
+        self, account_monitor: AccountMonitor, start_at: str, end_at: str
+    ) -> JSON:
+        """
+        Logs into the account being monitored and fetches the Rapid Rewards points
+        activity for the provided date window.
+        """
+        driver = self._get_driver()
+        driver.add_cdp_listener("Network.responseReceived", self._login_listener)
+
+        logger.debug("Loading Rapid Rewards activity page (this may take a moment)")
+        driver.get(RAPID_REWARDS_URL)
+
+        logger.debug("Logging into account to get Rapid Rewards points activity")
+        self._take_debug_screenshot(driver, "pre_points_login.png")
+        time.sleep(random_sleep_duration(1, 3))
+        driver.type('input[id="username"]', account_monitor.username)
+        driver.type('input[id="password"]', f"{account_monitor.password}\n")
+
+        self._wait_for_attribute(driver, "headers_set")
+        self._wait_for_login(driver, account_monitor)
+        self._take_debug_screenshot(driver, "post_points_login.png")
+
+        transactions = self._fetch_points_transactions(driver, start_at, end_at)
+        self._quit_driver(driver)
+        return transactions
 
     def _get_driver(self) -> Driver:
         logger.debug("Starting webdriver for current session")
@@ -257,6 +289,30 @@ class WebDriver:
         trips_response = self._get_response_body(driver, self.trips_request_id)
         reservations = trips_response["data"]
         return reservations
+
+    def _fetch_points_transactions(self, driver: Driver, start_at: str, end_at: str) -> JSON:
+        logger.debug("Retrieving Rapid Rewards points activity from %s to %s", start_at, end_at)
+        response = driver.execute_async_script(
+            """
+            const [baseUrl, startAt, endAt, done] = arguments;
+            const url = `${baseUrl}?start_at=${encodeURIComponent(startAt)}&end_at=${encodeURIComponent(endAt)}`;
+
+            fetch(url, { credentials: "include" })
+              .then(async response => {
+                const text = await response.text();
+                done({ status: response.status, body: text });
+              })
+              .catch(error => done({ error: String(error) }));
+            """,
+            POINTS_TRANSACTIONS_URL,
+            start_at,
+            end_at,
+        )
+
+        if response.get("error"):
+            raise RuntimeError(f"Failed to retrieve points activity: {response['error']}")
+
+        return json.loads(response["body"])
 
     def _get_response_body(self, driver: Driver, request_id: str) -> JSON:
         response = driver.execute_cdp_cmd("Network.getResponseBody", {"requestId": request_id})

--- a/tests/integration/test_fare_checker.py
+++ b/tests/integration/test_fare_checker.py
@@ -14,6 +14,7 @@ from lib.fare_checker import BOOKING_URL, FareChecker
 from lib.flight import Flight
 from lib.reservation_monitor import ReservationMonitor
 from lib.utils import BASE_URL, CheckFaresOption, FlightChangeError
+from lib.webdriver import WebDriver
 
 CHANGE_FLIGHT_URL = BASE_URL + BOOKING_URL + "change_page"
 MATCHING_FLIGHTS_URL = BASE_URL + BOOKING_URL + "matching_flights"
@@ -106,7 +107,7 @@ def monitor() -> ReservationMonitor:
 @pytest.fixture
 def flight() -> Flight:
     flight_info = {
-        "arrivalAirport": {"name": "test_inbound", "country": None},
+        "arrivalAirport": {"code": "SYD", "name": "test_inbound", "country": None},
         "departureAirport": {"code": "LAX", "name": "test_outbound"},
         "departureDate": "2021-12-06",
         "departureTime": "14:40",
@@ -222,13 +223,57 @@ def test_no_fare_drop(
     monitor.notification_handler.lower_fare.assert_not_called()
 
 
-def test_flight_error_with_companion(monitor: ReservationMonitor, flight: Flight) -> None:
+def test_flight_error_with_companion(
+    requests_mock: RequestMocker, monitor: ReservationMonitor, flight: Flight
+) -> None:
     message = {"body": "You must first cancel the associated companion reservation."}
     flight.reservation_info["greyBoxMessage"] = message
+    flight.reservation_info["bounds"][0]["fareProductDetails"] = {"fareProductId": "WGARED"}
+    monitor.username = "test-user"
+    monitor.password = "test-password"
 
-    fare_checker = FareChecker(monitor)
-    with pytest.raises(FlightChangeError):
+    mock_points_transactions = mock.Mock(
+        return_value={
+            "data": [
+                {
+                    "product_category": "FLIGHT",
+                    "transaction_type": "REDEEM",
+                    "transaction_at": "2026-01-01T12:00:00Z",
+                    "flight_details": {
+                        "record_locator": "TEST",
+                        "origination_airport_code": "LAX",
+                        "destination_airport_code": "SYD",
+                        "depart_at": "2021-12-06T14:40:00",
+                    },
+                    "points_detail": {
+                        "transaction_points": {"amount": "20,000", "currency": "PTS"}
+                    },
+                }
+            ]
+        }
+    )
+
+    flights = copy.deepcopy(FLIGHT_CARDS)
+    flights[2]["fares"] = [
+        {"_meta": {"fareProductId": "WGARED"}, "reasonIfUnavailable": "Unavailable"},
+        {
+            "_meta": {"fareProductId": "PLURED"},
+            "price": {"amount": "20,000", "currencyCode": "PTS"},
+            "priceDifference": {"sign": "+", "amount": "0", "currencyCode": "PTS"},
+        },
+    ]
+
+    matching_flights = copy.deepcopy(MATCHING_FLIGHTS)
+    matching_flights["changeShoppingPage"]["flights"]["outboundPage"]["cards"] = flights
+
+    requests_mock.get(CHANGE_FLIGHT_URL, [{"json": CHANGE_FLIGHT_PAGE, "status_code": 200}])
+    requests_mock.post(MATCHING_FLIGHTS_URL, [{"json": matching_flights, "status_code": 200}])
+    with mock.patch.object(WebDriver, "get_points_transactions", mock_points_transactions):
+        fare_checker = FareChecker(monitor)
         fare_checker.check_flight_price(flight)
+
+    monitor.notification_handler.lower_fare.assert_not_called()
+    mock_points_transactions.assert_called_once()
 
 
 def test_flight_error_when_no_change_link_exists(

--- a/tests/integration/test_fare_checker.py
+++ b/tests/integration/test_fare_checker.py
@@ -17,6 +17,8 @@ from lib.utils import BASE_URL, CheckFaresOption, FlightChangeError
 
 CHANGE_FLIGHT_URL = BASE_URL + BOOKING_URL + "change_page"
 MATCHING_FLIGHTS_URL = BASE_URL + BOOKING_URL + "matching_flights"
+CANCEL_BOUND_URL = BASE_URL + BOOKING_URL + "cancel_bound"
+REFUND_QUOTE_URL = BASE_URL + BOOKING_URL + "refund_quote"
 
 CHANGE_FLIGHT_PAGE = {
     "changeFlightPage": {
@@ -237,6 +239,63 @@ def test_flight_error_when_no_change_link_exists(
     fare_checker = FareChecker(monitor)
     with pytest.raises(FlightChangeError):
         fare_checker.check_flight_price(flight)
+
+
+def test_basic_fare_drop_uses_upgrade_prices_when_basic_is_unavailable(
+    requests_mock: RequestMocker, monitor: ReservationMonitor, flight: Flight
+) -> None:
+    flights = copy.deepcopy(FLIGHT_CARDS)
+    flights[2]["fares"] = [
+        {
+            "_meta": {"fareProductId": "WGA"},
+            "reasonIfUnavailable": "Unavailable",
+        },
+        {
+            "_meta": {"fareProductId": "PLU"},
+            "price": {"amount": "60", "currencyCode": "USD"},
+            "priceDifference": {"sign": "+", "amount": "19", "currencyCode": "USD"},
+        },
+        {
+            "_meta": {"fareProductId": "ANY"},
+            "price": {"amount": "130", "currencyCode": "USD"},
+            "priceDifference": {"sign": "+", "amount": "51", "currencyCode": "USD"},
+        },
+    ]
+
+    matching_flights = copy.deepcopy(MATCHING_FLIGHTS)
+    matching_flights["changeShoppingPage"]["flights"]["outboundPage"]["cards"] = flights
+    flight.reservation_info["_links"]["cancelBound"] = {
+        "href": "cancel_bound",
+        "method": "GET",
+        "query": {},
+    }
+    cancel_bound_page = {
+        "viewForCancelBoundPage": {
+            "_links": {
+                "refundQuote": {
+                    "href": "refund_quote",
+                    "method": "POST",
+                    "body": {},
+                }
+            }
+        }
+    }
+    refund_quote_page = {
+        "cancelRefundQuotePage": {
+            "cancelBounds": [{"flight": "100\u200b/\u200b101"}],
+            "tripTotals": [{"amount": "79", "currencyCode": "USD"}],
+        }
+    }
+
+    requests_mock.get(CHANGE_FLIGHT_URL, [{"json": CHANGE_FLIGHT_PAGE, "status_code": 200}])
+    requests_mock.get(CANCEL_BOUND_URL, [{"json": cancel_bound_page, "status_code": 200}])
+    requests_mock.post(MATCHING_FLIGHTS_URL, [{"json": matching_flights, "status_code": 200}])
+    requests_mock.post(REFUND_QUOTE_URL, [{"json": refund_quote_page, "status_code": 200}])
+
+    fare_checker = FareChecker(monitor)
+    fare_checker.check_flight_price(flight)
+
+    monitor.notification_handler.lower_fare.assert_called_once_with(flight, "-38 USD")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_fare_checker.py
+++ b/tests/unit/test_fare_checker.py
@@ -78,7 +78,27 @@ class TestFareChecker:
         price = self.checker._get_flight_price(test_flight)
 
         assert price == {"amount": -300, "currencyCode": "PTS"}
-        mock_get_matching_fare.assert_called_once_with(["fare_one", "fare_two"], "test_fare")
+        mock_get_matching_fare.assert_called_once_with(["fare_one", "fare_two"], "test_fare", None)
+
+    def test_get_flight_price_retrieves_cancel_quote_for_wga_fares(
+        self, mocker: MockerFixture, test_flight: Flight
+    ) -> None:
+        flights = [{"flightNumbers": "100", "fares": ["fare_one"]}]
+        mocker.patch.object(FareChecker, "_get_matching_flights", return_value=(flights, "WGARED"))
+        mock_get_original_wga_fare = mocker.patch.object(
+            FareChecker, "_get_original_wga_fare", return_value={"amount": 21000, "currencyCode": "PTS"}
+        )
+        mock_get_matching_fare = mocker.patch.object(
+            FareChecker, "_get_matching_fare", return_value={"amount": 4000, "currencyCode": "PTS"}
+        )
+
+        price = self.checker._get_flight_price(test_flight)
+
+        assert price == {"amount": 4000, "currencyCode": "PTS"}
+        mock_get_original_wga_fare.assert_called_once_with(test_flight, flights)
+        mock_get_matching_fare.assert_called_once_with(
+            ["fare_one"], "WGARED", {"amount": 21000, "currencyCode": "PTS"}
+        )
 
     @pytest.mark.parametrize("bound", ["outbound", "inbound"])
     def test_get_matching_flights_retrieves_correct_bound_page(
@@ -175,6 +195,76 @@ class TestFareChecker:
             self.checker._get_change_flight_page(reservation_info)
 
         assert "cannot be changed" in str(err.value).lower()
+
+    def test_get_cancel_bound_page_retrieves_cancel_bound_page(
+        self, mocker: MockerFixture
+    ) -> None:
+        reservation_info = {
+            "greyBoxMessage": None,
+            "_links": {"cancelBound": {"href": "cancel_page", "method": "GET", "query": "query"}},
+        }
+        response = {"viewForCancelBoundPage": "test_page"}
+        mock_make_request = mocker.patch("lib.fare_checker.make_request", return_value=response)
+        mock_check_for_companion = mocker.patch.object(FareChecker, "_check_for_companion")
+
+        cancel_page = self.checker._get_cancel_bound_page(reservation_info)
+
+        mock_check_for_companion.assert_called_once_with(reservation_info)
+        assert cancel_page == "test_page"
+
+        call_args = mock_make_request.call_args[0]
+        assert call_args[1] == fare_checker.BOOKING_URL + "cancel_page"
+        assert call_args[3] == "query"
+
+    def test_get_cancel_bound_page_raises_exception_when_flight_cannot_be_cancelled(self) -> None:
+        reservation_info = {"greyBoxMessage": None, "_links": {"cancelBound": None}}
+
+        with pytest.raises(FlightChangeError) as err:
+            self.checker._get_cancel_bound_page(reservation_info)
+
+        assert "cannot be cancelled" in str(err.value).lower()
+
+    def test_get_cancel_refund_quote_page_retrieves_quote_page(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(
+            FareChecker,
+            "_get_cancel_bound_page",
+            return_value={"_links": {"refundQuote": {"href": "refund_quote", "method": "POST"}}},
+        )
+        mock_make_request = mocker.patch(
+            "lib.fare_checker.make_request", return_value={"cancelRefundQuotePage": "quote_page"}
+        )
+
+        quote_page = self.checker._get_cancel_refund_quote_page({"_links": {"cancelBound": "test"}})
+
+        assert quote_page == "quote_page"
+        call_args = mock_make_request.call_args[0]
+        assert call_args[1] == fare_checker.BOOKING_URL + "refund_quote"
+
+    def test_get_cancel_refund_total_returns_matching_trip_total(
+        self, mocker: MockerFixture, test_flight: Flight
+    ) -> None:
+        refund_quote_page = {
+            "cancelBounds": [{"flight": "100"}],
+            "tripTotals": [
+                {"amount": "21,000", "currencyCode": "PTS"},
+                {"amount": "5.60", "currencyCode": "USD"},
+            ],
+        }
+        mocker.patch.object(FareChecker, "_get_cancel_refund_quote_page", return_value=refund_quote_page)
+
+        amount = self.checker._get_cancel_refund_total(test_flight, "PTS")
+
+        assert amount == {"amount": 21000, "currencyCode": "PTS"}
+
+    def test_validate_cancel_refund_quote_raises_on_ambiguous_bounds(
+        self, test_flight: Flight
+    ) -> None:
+        refund_quote_page = {"cancelBounds": [{"flight": "100"}, {"flight": "200"}]}
+
+        with pytest.raises(FlightChangeError):
+            self.checker._validate_cancel_refund_quote(refund_quote_page, test_flight)
 
     def test_get_search_query_returns_the_correct_query_for_one_way(
         self, test_flight: Flight
@@ -326,6 +416,74 @@ class TestFareChecker:
         ]
         fare_price = self.checker._get_matching_fare(fares, "right_fare")
         assert fare_price == {"amount": -3000, "currencyCode": "PTS"}
+
+    def test_get_matching_fare_derives_basic_fare_difference_when_basic_is_unavailable(
+        self,
+    ) -> None:
+        fares = [
+            {
+                "_meta": {"fareProductId": "WGA"},
+                "reasonIfUnavailable": "Unavailable",
+            },
+            {
+                "_meta": {"fareProductId": "PLU"},
+                "price": {"amount": "179", "currencyCode": "USD"},
+                "priceDifference": {"amount": "100", "sign": "+", "currencyCode": "USD"},
+            },
+            {
+                "_meta": {"fareProductId": "ANY"},
+                "price": {"amount": "249", "currencyCode": "USD"},
+                "priceDifference": {"amount": "170", "sign": "+", "currencyCode": "USD"},
+            },
+        ]
+
+        fare_price = self.checker._get_matching_fare(
+            fares, "WGA", {"amount": 79, "currencyCode": "USD"}
+        )
+
+        assert fare_price == {"amount": 0, "currencyCode": "USD"}
+
+    def test_get_matching_fare_derives_red_basic_fare_difference_when_basic_is_unavailable(
+        self,
+    ) -> None:
+        fares = [
+            {
+                "_meta": {"fareProductId": "PLURED"},
+                "price": {"amount": "28,000", "currencyCode": "PTS"},
+                "priceDifference": {"amount": "7,000", "sign": "+", "currencyCode": "PTS"},
+            },
+            {
+                "_meta": {"fareProductId": "ANYRED"},
+                "price": {"amount": "34,500", "currencyCode": "PTS"},
+                "priceDifference": {"amount": "13,500", "sign": "+", "currencyCode": "PTS"},
+            },
+        ]
+
+        fare_price = self.checker._get_matching_fare(
+            fares, "WGARED", {"amount": 21000, "currencyCode": "PTS"}
+        )
+
+        assert fare_price == {"amount": 0, "currencyCode": "PTS"}
+
+    def test_get_matching_fare_falls_back_to_old_basic_fare_derivation_without_original_fare(
+        self,
+    ) -> None:
+        fares = [
+            {
+                "_meta": {"fareProductId": "PLURED"},
+                "price": {"amount": "28,000", "currencyCode": "PTS"},
+                "priceDifference": {"amount": "7,000", "sign": "+", "currencyCode": "PTS"},
+            },
+            {
+                "_meta": {"fareProductId": "ANYRED"},
+                "price": {"amount": "34,500", "currencyCode": "PTS"},
+                "priceDifference": {"amount": "13,500", "sign": "+", "currencyCode": "PTS"},
+            },
+        ]
+
+        fare_price = self.checker._get_matching_fare(fares, "WGARED")
+
+        assert fare_price == {"amount": 0, "currencyCode": "PTS"}
 
     @pytest.mark.parametrize("fares", [None, [], [{"_meta": {"fareProductId": "right_fare"}}]])
     def test_get_matching_fare_returns_nothing_when_price_is_not_available(

--- a/tests/unit/test_fare_checker.py
+++ b/tests/unit/test_fare_checker.py
@@ -23,9 +23,10 @@ def mock_sleep(mocker: MockerFixture) -> None:
 def test_flight(mocker: MockerFixture) -> Flight:
     mocker.patch.object(Flight, "_set_flight_time")
     flight_info = {
-        "departureAirport": {"name": None},
-        "arrivalAirport": {"name": None, "country": None},
-        "departureTime": None,
+        "departureAirport": {"code": "LAX", "name": None},
+        "arrivalAirport": {"code": "DAL", "name": None, "country": None},
+        "departureDate": "2026-03-27",
+        "departureTime": "18:05",
         "flights": [{"number": "WN100"}],
     }
 
@@ -80,7 +81,7 @@ class TestFareChecker:
         assert price == {"amount": -300, "currencyCode": "PTS"}
         mock_get_matching_fare.assert_called_once_with(["fare_one", "fare_two"], "test_fare", None)
 
-    def test_get_flight_price_retrieves_cancel_quote_for_wga_fares(
+    def test_get_flight_price_retrieves_original_fare_for_wga_fares(
         self, mocker: MockerFixture, test_flight: Flight
     ) -> None:
         flights = [{"flightNumbers": "100", "fares": ["fare_one"]}]
@@ -160,11 +161,9 @@ class TestFareChecker:
         }
         flight_page = {"changeFlightPage": "test_page"}
         mock_make_request = mocker.patch("lib.fare_checker.make_request", return_value=flight_page)
-        mock_check_for_companion = mocker.patch.object(FareChecker, "_check_for_companion")
 
         change_flight_page, fare_type_bounds = self.checker._get_change_flight_page(res_info)
 
-        mock_check_for_companion.assert_called_once()
         assert change_flight_page == "test_page"
         assert fare_type_bounds == ["bound_one", "bound_two"]
 
@@ -358,6 +357,90 @@ class TestFareChecker:
     def test_check_for_companion_passes_when_no_companion_exists(self, reservation: JSON) -> None:
         # An exception will be thrown if the test does not pass
         self.checker._check_for_companion(reservation)
+
+    def test_get_original_wga_fare_uses_points_activity_for_points_bookings(
+        self, mocker: MockerFixture, test_flight: Flight
+    ) -> None:
+        mocker.patch.object(FareChecker, "_get_wga_currency", return_value="PTS")
+        mock_get_points_fare = mocker.patch.object(
+            FareChecker,
+            "_get_original_wga_points_fare",
+            return_value={"amount": 21000, "currencyCode": "PTS"},
+        )
+        mock_get_cancel_refund_total = mocker.patch.object(FareChecker, "_get_cancel_refund_total")
+
+        original_fare = self.checker._get_original_wga_fare(test_flight, [])
+
+        assert original_fare == {"amount": 21000, "currencyCode": "PTS"}
+        mock_get_points_fare.assert_called_once_with(test_flight)
+        mock_get_cancel_refund_total.assert_not_called()
+
+    def test_get_original_wga_fare_uses_cancel_flow_for_cash_bookings(
+        self, mocker: MockerFixture, test_flight: Flight
+    ) -> None:
+        mocker.patch.object(FareChecker, "_get_wga_currency", return_value="USD")
+        mock_get_points_fare = mocker.patch.object(FareChecker, "_get_original_wga_points_fare")
+        mock_get_cancel_refund_total = mocker.patch.object(
+            FareChecker, "_get_cancel_refund_total", return_value={"amount": 79, "currencyCode": "USD"}
+        )
+
+        original_fare = self.checker._get_original_wga_fare(test_flight, [])
+
+        assert original_fare == {"amount": 79, "currencyCode": "USD"}
+        mock_get_points_fare.assert_not_called()
+        mock_get_cancel_refund_total.assert_called_once_with(test_flight, "USD")
+
+    def test_get_original_wga_points_fare_returns_matching_transaction(
+        self, mocker: MockerFixture, test_flight: Flight
+    ) -> None:
+        transaction = {
+            "points_detail": {"transaction_points": {"amount": "21,000", "currency": "PTS"}}
+        }
+        mocker.patch.object(FareChecker, "_get_points_transactions", return_value=[transaction])
+        mocker.patch.object(
+            FareChecker, "_match_points_redemption_transaction", return_value=transaction
+        )
+
+        original_fare = self.checker._get_original_wga_points_fare(test_flight)
+
+        assert original_fare == {"amount": 21000, "currencyCode": "PTS"}
+
+    def test_match_points_redemption_transaction_returns_latest_match(
+        self, test_flight: Flight
+    ) -> None:
+        transactions = [
+            {
+                "product_category": "FLIGHT",
+                "transaction_type": "REDEEM",
+                "transaction_at": "2026-01-01T12:00:00Z",
+                "flight_details": {
+                    "record_locator": "",
+                    "origination_airport_code": "LAX",
+                    "destination_airport_code": "DAL",
+                    "depart_at": "2026-03-27T18:05:00",
+                },
+                "points_detail": {"transaction_points": {"currency": "PTS", "amount": "20000"}},
+            },
+            {
+                "product_category": "FLIGHT",
+                "transaction_type": "REDEEM",
+                "transaction_at": "2026-01-02T12:00:00Z",
+                "flight_details": {
+                    "record_locator": "",
+                    "origination_airport_code": "LAX",
+                    "destination_airport_code": "DAL",
+                    "depart_at": "2026-03-27T18:05:00",
+                },
+                "points_detail": {"transaction_points": {"currency": "PTS", "amount": "21000"}},
+            },
+        ]
+
+        match = self.checker._match_points_redemption_transaction(test_flight, transactions)
+
+        assert match == transactions[1]
+
+    def test_get_points_transactions_returns_none_without_account_credentials(self) -> None:
+        assert self.checker._get_points_transactions() is None
 
     def test_get_lowest_fare_returns_lowest_matching_fare(
         self, mocker: MockerFixture, test_flight: Flight

--- a/tests/unit/test_webdriver.py
+++ b/tests/unit/test_webdriver.py
@@ -9,6 +9,7 @@ from lib.utils import DriverTimeoutError, LoginError
 from lib.webdriver import (
     INVALID_CREDENTIALS_CODE,
     MOBILE_HEADERS_URL,
+    RAPID_REWARDS_URL,
     SUCCESSFUL_LOGIN_URL,
     TRIPS_URL,
     WebDriver,
@@ -77,6 +78,30 @@ class TestWebDriver:
         mock_chrome.add_cdp_listener.assert_called_once()
         # Ensure the driver navigates to the normal website to fetch reservations
         mock_chrome.get.assert_called_once()
+        mock_chrome.quit.assert_called_once()
+
+    def test_get_points_transactions_fetches_activity(
+        self, mocker: MockerFixture, mock_chrome: mock.Mock, mock_account_monitor: mock.Mock
+    ) -> None:
+        mocker.patch("time.sleep")
+        mocker.patch.object(WebDriver, "_get_driver", return_value=mock_chrome)
+        mock_wait_for_attribute = mocker.patch.object(self.driver, "_wait_for_attribute")
+        mock_wait_for_login = mocker.patch.object(WebDriver, "_wait_for_login")
+        mock_fetch_points_transactions = mocker.patch.object(
+            WebDriver, "_fetch_points_transactions", return_value={"data": ["txn"]}
+        )
+
+        transactions = self.driver.get_points_transactions(
+            mock_account_monitor, "2025-03-12", "2026-03-12"
+        )
+
+        assert transactions == {"data": ["txn"]}
+        mock_wait_for_attribute.assert_called_once()
+        mock_wait_for_login.assert_called_once()
+        mock_fetch_points_transactions.assert_called_once_with(
+            mock_chrome, "2025-03-12", "2026-03-12"
+        )
+        mock_chrome.get.assert_called_once_with(RAPID_REWARDS_URL)
         mock_chrome.quit.assert_called_once()
 
     def test_get_driver_returns_a_webdriver_with_one_request(self, mock_chrome: mock.Mock) -> None:
@@ -237,6 +262,18 @@ class TestWebDriver:
         mocker.patch.object(WebDriver, "_get_response_body", return_value=trips_response)
 
         assert self.driver._fetch_reservations(None) == ["flight1", "flight2"]
+
+    def test_fetch_points_transactions_returns_json(self, mock_chrome: mock.Mock) -> None:
+        mock_chrome.execute_async_script.return_value = {
+            "status": 200,
+            "body": '{"data": [{"id": "transaction"}]}',
+        }
+
+        transactions = self.driver._fetch_points_transactions(
+            mock_chrome, "2025-03-12", "2026-03-12"
+        )
+
+        assert transactions == {"data": [{"id": "transaction"}]}
 
     def test_get_response_body_loads_body_from_response(self, mock_chrome: mock.Mock) -> None:
         mock_chrome.execute_cdp_cmd.return_value = {"body": '{"response": "body"}'}


### PR DESCRIPTION
fix fare checking for non-changeable basic fares by reading the booked WGA amount from the cancel refund quote API
- derive the current basic fare from change-shopping upgrade prices and price differences instead of treating WGA fares as unavailable
- add unit and integration coverage for WGA and WGARED fare checks

Testing
- .venv/bin/pytest -p no:rerunfailures tests/unit/test_fare_checker.py\n

- .venv/bin/pytest -p no:rerunfailures tests/integration/test_fare_checker.py

- Fixes #379 
- Fixes #386